### PR TITLE
feat: implement imu_aceinna_openimu_nmea_publisher

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -449,6 +449,43 @@ Status byte (least significant to most significant):
 | 1 | Turn switch |
 | 1 | Course is used as heading |
 
+## e4 - INS Output Message
+
+| Offset | Type   | Description |
+|--------|--------|--------------------------|
+| 0 | uint32 | GPS time of week (ms) |
+| 4 | uint8 | Filter Flags (see below) |
+| 5 | float | imu_ned2ned_rot - q.w |
+| 9 | float | imu_ned2ned_rot - q.x |
+| 13 | float | imu_ned2ned_rot - q.y |
+| 17 | float | imu_ned2ned_rot - q.z |
+| 21 | float | imu_ned2ned_angv - x (deg) |
+| 25 | float | imu_ned2ned_angv - y (deg) |
+| 29 | float | imu_ned2ned_angv - z (deg) |
+| 33 | float | imu_ned2ned_linv - x |
+| 37 | float | imu_ned2ned_linv - y |
+| 41 | float | imu_ned2ned_linv - z |
+| 49 | double | latitude (deg) |
+| 57 | double | longitude (deg) |
+| 65 | double | altitude over MSL |
+| 65 | float | mag.x |
+| 69 | float | mag.y |
+| 73 | float | mag.z |
+| 77 | float | mag_euler.x |
+| 81 | float | mag_euler.y |
+| 85 | float | mag_euler.z |
+| 89 | float | declination |
+
+Filter state byte (least significant to most significant):
+
+| Length (bit) | Description |
+|--------------|-------------|
+| 3 | Algorithm state (see beginning of section) |
+| 1 | Still switch |
+| 1 | Turn switch |
+| 1 | Course is used as heading |
+
+
 ## s1 - IMU Scaled Sensors
 
 | Offset | Type   | Description |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,3 +8,5 @@ rock_library(imu_aceinna_openimu
 rock_executable(imu_aceinna_openimu_ctl Main.cpp
     DEPS imu_aceinna_openimu)
 
+rock_executable(imu_aceinna_openimu_nmea_publisher NMEAPublisher.cpp MainNMEAPublisher.cpp
+    DEPS imu_aceinna_openimu)

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -4,35 +4,44 @@
 using namespace std;
 using namespace imu_aceinna_openimu;
 
-static string axisToUser(OrientationAxis axis) {
-    switch(axis) {
-        case ORIENTATION_AXIS_PLUS_X: return "+X";
-        case ORIENTATION_AXIS_MINUS_X: return "-X";
-        case ORIENTATION_AXIS_PLUS_Y: return "+Y";
-        case ORIENTATION_AXIS_MINUS_Y: return "-Y";
-        case ORIENTATION_AXIS_PLUS_Z: return "+Z";
-        case ORIENTATION_AXIS_MINUS_Z: return "-Z";
+static string axisToUser(OrientationAxis axis)
+{
+    switch (axis) {
+        case ORIENTATION_AXIS_PLUS_X:
+            return "+X";
+        case ORIENTATION_AXIS_MINUS_X:
+            return "-X";
+        case ORIENTATION_AXIS_PLUS_Y:
+            return "+Y";
+        case ORIENTATION_AXIS_MINUS_Y:
+            return "-Y";
+        case ORIENTATION_AXIS_PLUS_Z:
+            return "+Z";
+        case ORIENTATION_AXIS_MINUS_Z:
+            return "-Z";
         default:
             throw std::invalid_argument("axisToUser: invalid axis");
     }
 }
 
-Configuration::Orientation::Orientation() {
+Configuration::Orientation::Orientation()
+{
 }
-Configuration::Orientation::Orientation(OrientationAxis forward, OrientationAxis right, OrientationAxis down)
+Configuration::Orientation::Orientation(OrientationAxis forward,
+    OrientationAxis right,
+    OrientationAxis down)
     : forward(forward)
     , right(right)
-    , down(down) {
-}
-
-bool Configuration::Orientation::operator ==(Orientation const& other) const
+    , down(down)
 {
-    return forward == other.forward &&
-           right == other.right &&
-           down == other.down;
 }
 
-bool Configuration::Orientation::operator !=(Orientation const& other) const
+bool Configuration::Orientation::operator==(Orientation const& other) const
+{
+    return forward == other.forward && right == other.right && down == other.down;
+}
+
+bool Configuration::Orientation::operator!=(Orientation const& other) const
 {
     return !(*this == other);
 }

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -1,8 +1,8 @@
 #ifndef IMU_ACEINNA_OPENIMU_CONFIGURATION_HPP
 #define IMU_ACEINNA_OPENIMU_CONFIGURATION_HPP
 
-#include <string>
 #include <base/Eigen.hpp>
+#include <string>
 
 namespace imu_aceinna_openimu {
     enum OrientationAxis {
@@ -31,10 +31,12 @@ namespace imu_aceinna_openimu {
             OrientationAxis down = ORIENTATION_AXIS_PLUS_Z;
 
             Orientation();
-            Orientation(OrientationAxis forward, OrientationAxis right, OrientationAxis down);
+            Orientation(OrientationAxis forward,
+                OrientationAxis right,
+                OrientationAxis down);
 
-            bool operator ==(Orientation const& other) const;
-            bool operator !=(Orientation const& other) const;
+            bool operator==(Orientation const& other) const;
+            bool operator!=(Orientation const& other) const;
         };
 
         std::string periodic_packet_type = "z1";
@@ -55,9 +57,14 @@ namespace imu_aceinna_openimu {
         base::Vector3d point_of_interest;
     };
 
-    inline std::string to_string(std::string const& value) { return value; }
-    template<typename T>
-    std::string to_string(T const& value) { return std::to_string(value); }
+    inline std::string to_string(std::string const& value)
+    {
+        return value;
+    }
+    template <typename T> std::string to_string(T const& value)
+    {
+        return std::to_string(value);
+    }
     std::string to_string(Configuration::Orientation const& orientation);
 }
 

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -1,11 +1,11 @@
 #ifndef IMU_ACEINNA_OPENIMU_DRIVER_HPP
 #define IMU_ACEINNA_OPENIMU_DRIVER_HPP
 
-#include <iodrivers_base/Driver.hpp>
-#include <imu_aceinna_openimu/DeviceInfo.hpp>
 #include <imu_aceinna_openimu/Configuration.hpp>
+#include <imu_aceinna_openimu/DeviceInfo.hpp>
 #include <imu_aceinna_openimu/PeriodicUpdate.hpp>
 #include <imu_aceinna_openimu/Status.hpp>
+#include <iodrivers_base/Driver.hpp>
 #include <iosfwd>
 
 namespace imu_aceinna_openimu {
@@ -22,16 +22,17 @@ namespace imu_aceinna_openimu {
         Status mStatus;
         PeriodicUpdate mPeriodicUpdate;
 
-        template<typename T>
+        template <typename T>
         void writeConfigurationGeneric(int index, T value, bool validate);
 
         virtual int extractPacket(uint8_t const* buffer, size_t buffer_size) const;
 
         /** Read packets until a packet of type 'command' is found
          */
-        int readPacketsUntil(uint8_t* buffer, int bufferSize, uint8_t const* command,
-                             base::Time timeout);
-
+        int readPacketsUntil(uint8_t* buffer,
+            int bufferSize,
+            uint8_t const* command,
+            base::Time timeout);
 
         /** @overload */
         int readPacketsUntil(uint8_t* buffer, int bufferSize, uint8_t const* command);
@@ -73,7 +74,8 @@ namespace imu_aceinna_openimu {
         void queryRestoreDefaultConfiguration();
 
         /** Write a whole configuration */
-        void writeConfiguration(Configuration const& configuration, bool validate = false);
+        void writeConfiguration(Configuration const& configuration,
+            bool validate = false);
 
         /** Write a single configuration parameter
          *
@@ -84,7 +86,7 @@ namespace imu_aceinna_openimu {
          * @param validate if true, the method will re-read the configuration parameter
          *        to ensure it has been properly updated
          */
-        template<typename T>
+        template <typename T>
         void writeConfiguration(int index, T value, bool validate = false);
 
         /** Configure the periodic packet */
@@ -127,8 +129,7 @@ namespace imu_aceinna_openimu {
          * The type must either be int64_t or std::string. Other values will fail
          * at link time.
          */
-        template<typename T>
-        T readConfiguration(int index);
+        template <typename T> T readConfiguration(int index);
 
         /** Switch to bootloader mode
          *
@@ -154,13 +155,14 @@ namespace imu_aceinna_openimu {
 
         /** Return the last IMU status received by processOne
          *
-         * This is named getIMUStatus() to avoid clashing with iodrivers_base::Driver::getStatus()
+         * This is named getIMUStatus() to avoid clashing with
+         * iodrivers_base::Driver::getStatus()
          */
         Status getIMUStatus() const;
 
         /** Write a new app firmware */
         void writeFirmware(std::vector<uint8_t> const& data,
-                           std::ostream& progress = nullStream());
+            std::ostream& progress = nullStream());
     };
 }
 

--- a/src/Endianness.hpp
+++ b/src/Endianness.hpp
@@ -6,68 +6,69 @@
 
 namespace imu_aceinna_openimu {
     namespace endianness {
-        template<typename T>
-        uint8_t const* decode(uint8_t const* buffer, T& value,
-                              typename std::enable_if<sizeof(T) == 8>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t const* decode(uint8_t const* buffer,
+            T& value,
+            typename std::enable_if<sizeof(T) == 8>::type* enabler = nullptr)
         {
-            uint64_t result =
-                static_cast<uint64_t>(buffer[0]) << 0 |
-                static_cast<uint64_t>(buffer[1]) << 8 |
-                static_cast<uint64_t>(buffer[2]) << 16 |
-                static_cast<uint64_t>(buffer[3]) << 24 |
-                static_cast<uint64_t>(buffer[4]) << 32 |
-                static_cast<uint64_t>(buffer[5]) << 40 |
-                static_cast<uint64_t>(buffer[6]) << 48 |
-                static_cast<uint64_t>(buffer[7]) << 56;
+            uint64_t result = static_cast<uint64_t>(buffer[0]) << 0 |
+                              static_cast<uint64_t>(buffer[1]) << 8 |
+                              static_cast<uint64_t>(buffer[2]) << 16 |
+                              static_cast<uint64_t>(buffer[3]) << 24 |
+                              static_cast<uint64_t>(buffer[4]) << 32 |
+                              static_cast<uint64_t>(buffer[5]) << 40 |
+                              static_cast<uint64_t>(buffer[6]) << 48 |
+                              static_cast<uint64_t>(buffer[7]) << 56;
             value = reinterpret_cast<T const&>(result);
             return buffer + sizeof(T);
         }
 
-        template<typename T>
-        uint8_t const* decode(uint8_t const* buffer, T& value,
-                              typename std::enable_if<sizeof(T) == 4>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t const* decode(uint8_t const* buffer,
+            T& value,
+            typename std::enable_if<sizeof(T) == 4>::type* enabler = nullptr)
         {
-            uint32_t result =
-                static_cast<uint64_t>(buffer[0]) << 0 |
-                static_cast<uint64_t>(buffer[1]) << 8 |
-                static_cast<uint64_t>(buffer[2]) << 16 |
-                static_cast<uint64_t>(buffer[3]) << 24;
+            uint32_t result = static_cast<uint64_t>(buffer[0]) << 0 |
+                              static_cast<uint64_t>(buffer[1]) << 8 |
+                              static_cast<uint64_t>(buffer[2]) << 16 |
+                              static_cast<uint64_t>(buffer[3]) << 24;
             value = reinterpret_cast<T const&>(result);
             return buffer + sizeof(T);
         }
 
-        template<typename T>
-        uint8_t const* decode(uint8_t const* buffer, T& value,
-                              typename std::enable_if<sizeof(T) == 2>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t const* decode(uint8_t const* buffer,
+            T& value,
+            typename std::enable_if<sizeof(T) == 2>::type* enabler = nullptr)
         {
-            uint16_t result =
-                static_cast<uint16_t>(buffer[0]) << 0 |
-                static_cast<uint16_t>(buffer[1]) << 8;
+            uint16_t result = static_cast<uint16_t>(buffer[0]) << 0 |
+                              static_cast<uint16_t>(buffer[1]) << 8;
             value = reinterpret_cast<T const&>(result);
             return buffer + 2;
         }
 
-        template<typename T>
-        uint8_t const* decode(uint8_t const* buffer, T& value,
-                              typename std::enable_if<sizeof(T) == 1>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t const* decode(uint8_t const* buffer,
+            T& value,
+            typename std::enable_if<sizeof(T) == 1>::type* enabler = nullptr)
         {
             value = reinterpret_cast<T const&>(buffer[0]);
             return buffer + 1;
         }
 
-        template<typename T>
+        template <typename T>
         uint8_t const* decode(uint8_t const* buffer, T& value, uint8_t const* end)
         {
-            if (buffer + sizeof(T) > end)
-            {
+            if (buffer + sizeof(T) > end) {
                 throw std::invalid_argument("buffer too small");
             }
             return decode<T>(buffer, value);
         }
 
-        template<typename T>
-        uint8_t* encode(uint8_t* buffer, T const& value,
-                        typename std::enable_if<sizeof(T) == 8>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t* encode(uint8_t* buffer,
+            T const& value,
+            typename std::enable_if<sizeof(T) == 8>::type* enabler = nullptr)
         {
             uint64_t bytes = reinterpret_cast<uint64_t const&>(value);
             buffer[0] = (bytes >> 0) & 0xFF;
@@ -81,9 +82,10 @@ namespace imu_aceinna_openimu {
             return buffer + 8;
         }
 
-        template<typename T>
-        uint8_t* encode(uint8_t* buffer, T const& value,
-                        typename std::enable_if<sizeof(T) == 4>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t* encode(uint8_t* buffer,
+            T const& value,
+            typename std::enable_if<sizeof(T) == 4>::type* enabler = nullptr)
         {
             uint32_t bytes = reinterpret_cast<uint32_t const&>(value);
             buffer[0] = (bytes >> 0) & 0xFF;
@@ -93,9 +95,10 @@ namespace imu_aceinna_openimu {
             return buffer + 4;
         }
 
-        template<typename T>
-        uint8_t* encode(uint8_t* buffer, T const& value,
-                        typename std::enable_if<sizeof(T) == 2>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t* encode(uint8_t* buffer,
+            T const& value,
+            typename std::enable_if<sizeof(T) == 2>::type* enabler = nullptr)
         {
             uint16_t bytes = reinterpret_cast<uint16_t const&>(value);
             buffer[0] = (bytes >> 0) & 0xFF;
@@ -103,9 +106,10 @@ namespace imu_aceinna_openimu {
             return buffer + 2;
         }
 
-        template<typename T>
-        uint8_t* encode(uint8_t* buffer, T const& value,
-                        typename std::enable_if<sizeof(T) == 1>::type* enabler = nullptr)
+        template <typename T>
+        uint8_t* encode(uint8_t* buffer,
+            T const& value,
+            typename std::enable_if<sizeof(T) == 1>::type* enabler = nullptr)
         {
             buffer[0] = reinterpret_cast<uint8_t const&>(value);
             return buffer + 1;

--- a/src/FilterState.cpp
+++ b/src/FilterState.cpp
@@ -3,7 +3,8 @@
 using namespace std;
 using namespace imu_aceinna_openimu;
 
-string FilterState::toString() const {
+string FilterState::toString() const
+{
     string result;
     if (mode == OPMODE_STABILIZING) {
         result = "STABILIZING";

--- a/src/MagneticInfo.hpp
+++ b/src/MagneticInfo.hpp
@@ -1,9 +1,9 @@
 #ifndef IMU_ACEINNA_OPENIMU_MAGNETICINFO_HPP
 #define IMU_ACEINNA_OPENIMU_MAGNETICINFO_HPP
 
-#include <base/Time.hpp>
 #include <base/Angle.hpp>
 #include <base/Eigen.hpp>
+#include <base/Time.hpp>
 
 namespace imu_aceinna_openimu {
     /**

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,8 +1,8 @@
-#include <iostream>
+#include <fstream>
 #include <imu_aceinna_openimu/Driver.hpp>
 #include <imu_aceinna_openimu/Protocol.hpp>
-#include <fstream>
 #include <iomanip>
+#include <iostream>
 
 using namespace std;
 using namespace imu_aceinna_openimu;
@@ -23,27 +23,28 @@ struct Parameter {
 };
 
 static const Parameter PARAMETERS[] = {
-    { "periodic-packet-type", 3, PARAM_STRING, nullptr },
-    { "periodic-packet-rate", 4, PARAM_INTEGER, nullptr },
-    { "acceleration-filter", 5, PARAM_INTEGER, nullptr },
-    { "angular-velocity-filter", 6, PARAM_INTEGER, nullptr },
-    { "orientation", 7, PARAM_ORIENTATION, nullptr },
-    { "gps-baudrate", 8, PARAM_INTEGER, nullptr },
-    { "gps-protocol", 9, PARAM_OTHER, nullptr },
-    { "hard-iron-x", 10, PARAM_DOUBLE, nullptr },
-    { "hard-iron-y", 11, PARAM_DOUBLE, nullptr },
-    { "soft-iron-ratio", 12, PARAM_DOUBLE, nullptr },
-    { "soft-iron-angle", 13, PARAM_DOUBLE, nullptr },
-    { "lever-arm-x", 14, PARAM_DOUBLE, nullptr },
-    { "lever-arm-y", 15, PARAM_DOUBLE, nullptr },
-    { "lever-arm-z", 16, PARAM_DOUBLE, nullptr },
-    { "point-of-interest-x", 17, PARAM_DOUBLE, nullptr },
-    { "point-of-interest-y", 18, PARAM_DOUBLE, nullptr },
-    { "point-of-interest-z", 19, PARAM_DOUBLE, nullptr },
-    { nullptr, 0, PARAM_OTHER }
+    {   "periodic-packet-type",  3,      PARAM_STRING, nullptr},
+    {   "periodic-packet-rate",  4,     PARAM_INTEGER, nullptr},
+    {    "acceleration-filter",  5,     PARAM_INTEGER, nullptr},
+    {"angular-velocity-filter",  6,     PARAM_INTEGER, nullptr},
+    {            "orientation",  7, PARAM_ORIENTATION, nullptr},
+    {           "gps-baudrate",  8,     PARAM_INTEGER, nullptr},
+    {           "gps-protocol",  9,       PARAM_OTHER, nullptr},
+    {            "hard-iron-x", 10,      PARAM_DOUBLE, nullptr},
+    {            "hard-iron-y", 11,      PARAM_DOUBLE, nullptr},
+    {        "soft-iron-ratio", 12,      PARAM_DOUBLE, nullptr},
+    {        "soft-iron-angle", 13,      PARAM_DOUBLE, nullptr},
+    {            "lever-arm-x", 14,      PARAM_DOUBLE, nullptr},
+    {            "lever-arm-y", 15,      PARAM_DOUBLE, nullptr},
+    {            "lever-arm-z", 16,      PARAM_DOUBLE, nullptr},
+    {    "point-of-interest-x", 17,      PARAM_DOUBLE, nullptr},
+    {    "point-of-interest-y", 18,      PARAM_DOUBLE, nullptr},
+    {    "point-of-interest-z", 19,      PARAM_DOUBLE, nullptr},
+    {                  nullptr,  0,       PARAM_OTHER        }
 };
 
-Parameter const* findParameter(string name) {
+Parameter const* findParameter(string name)
+{
     for (auto p = PARAMETERS; p->name; ++p) {
         if (p->name == name) {
             return p;
@@ -52,7 +53,8 @@ Parameter const* findParameter(string name) {
     return nullptr;
 }
 
-void displayParameters(ostream& stream) {
+void displayParameters(ostream& stream)
+{
     for (auto p = PARAMETERS; p->name; ++p) {
         stream << "\n" << p->name;
         if (p->doc) {
@@ -67,15 +69,16 @@ struct GPSProtocolDescription {
 };
 
 GPSProtocolDescription GPS_PROTOCOLS[] = {
-    { GPS_AUTO, "auto" },
-    { GPS_UBLOX, "ublox" },
-    { GPS_NOVATEL_BINARY, "novatel-binary" },
-    { GPS_NOVATEL_ASCII, "novatel-ascii" },
-    { GPS_NMEA0183, "nmea" },
-    { GPS_SIRF_BINARY, "sirf-binary" }
+    {          GPS_AUTO,           "auto"},
+    {         GPS_UBLOX,          "ublox"},
+    {GPS_NOVATEL_BINARY, "novatel-binary"},
+    { GPS_NOVATEL_ASCII,  "novatel-ascii"},
+    {      GPS_NMEA0183,           "nmea"},
+    {   GPS_SIRF_BINARY,    "sirf-binary"}
 };
 
-void gpsDisplayProtocolList(ostream& out) {
+void gpsDisplayProtocolList(ostream& out)
+{
     bool first = true;
     for (auto i : GPS_PROTOCOLS) {
         if (!first)
@@ -84,7 +87,8 @@ void gpsDisplayProtocolList(ostream& out) {
     }
 }
 
-string gpsProtocolToString(GPSProtocol protocol) {
+string gpsProtocolToString(GPSProtocol protocol)
+{
     for (auto i : GPS_PROTOCOLS) {
         if (protocol == i.protocol) {
             return i.name;
@@ -93,7 +97,8 @@ string gpsProtocolToString(GPSProtocol protocol) {
     throw std::invalid_argument("unknown protocol code " + to_string(protocol));
 }
 
-GPSProtocol gpsProtocolFromString(string name) {
+GPSProtocol gpsProtocolFromString(string name)
+{
     for (auto i : GPS_PROTOCOLS) {
         if (name == i.name) {
             return i.protocol;
@@ -118,8 +123,10 @@ int usage()
         << "  find-rate         find the baud rate on a serial line. Do not specify\n"
         << "                    the rate in the URI\n"
         << "  set-period PACKET PERIOD set period of a specific packet. Only effective\n"
-        << "                    if periodic-packet-type is set to EP. PERIOD is a number of\n"
-        << "                    periods as set by periodic-packet-rate. For instance, if\n"
+        << "                    if periodic-packet-type is set to EP. PERIOD is a number "
+           "of\n"
+        << "                    periods as set by periodic-packet-rate. For instance, "
+           "if\n"
         << "                    periodic-packet-rate is 10 and PERIOD is 10, the actual\n"
         << "                    packet period is 1s (100ms base period * 10)\n"
         << "  set-rate RATE     change the baud rate. The new rate will be effective\n"
@@ -157,27 +164,29 @@ int main(int argc, char** argv)
         }
         else {
             auto conf = driver.readConfiguration();
-            cout
-                << "ID: " << info.device_id << "\n"
-                << "App: " << info.app_version << "\n"
-                << "Periodic packet type: " << conf.periodic_packet_type << "\n"
-                << "Periodic packet rate: " << conf.periodic_packet_rate << "\n"
-                << "Angular velocity low-pass filter: " << conf.angular_velocity_low_pass_filter << "\n"
-                << "Acceleration low-pass filter: " << conf.acceleration_low_pass_filter << "\n"
-                << "Orientation: " << to_string(conf.orientation) << "\n"
-                << "GPS Protocol: " << gpsProtocolToString(conf.gps_protocol) << "\n"
-                << "GPS Baud Rate: " << conf.gps_baud_rate << "\n"
-                << "Hard Iron: " << conf.hard_iron[0] << " " << conf.hard_iron[1] << "\n"
-                << "Soft Iron: ratio=" << conf.soft_iron_ratio << ", " << conf.soft_iron_angle << "\n"
-                << "Lever Arm: "
-                    << "x=" << conf.lever_arm.x() << ", "
-                    << "y=" << conf.lever_arm.y() << ", "
-                    << "z=" << conf.lever_arm.z() << "\n"
-                << "Point of Interest: "
-                    << "x=" << conf.point_of_interest.x() << ", "
-                    << "y=" << conf.point_of_interest.y() << ", "
-                    << "z=" << conf.point_of_interest.z() << "\n"
-                << flush;
+            cout << "ID: " << info.device_id << "\n"
+                 << "App: " << info.app_version << "\n"
+                 << "Periodic packet type: " << conf.periodic_packet_type << "\n"
+                 << "Periodic packet rate: " << conf.periodic_packet_rate << "\n"
+                 << "Angular velocity low-pass filter: "
+                 << conf.angular_velocity_low_pass_filter << "\n"
+                 << "Acceleration low-pass filter: " << conf.acceleration_low_pass_filter
+                 << "\n"
+                 << "Orientation: " << to_string(conf.orientation) << "\n"
+                 << "GPS Protocol: " << gpsProtocolToString(conf.gps_protocol) << "\n"
+                 << "GPS Baud Rate: " << conf.gps_baud_rate << "\n"
+                 << "Hard Iron: " << conf.hard_iron[0] << " " << conf.hard_iron[1] << "\n"
+                 << "Soft Iron: ratio=" << conf.soft_iron_ratio << ", "
+                 << conf.soft_iron_angle << "\n"
+                 << "Lever Arm: "
+                 << "x=" << conf.lever_arm.x() << ", "
+                 << "y=" << conf.lever_arm.y() << ", "
+                 << "z=" << conf.lever_arm.z() << "\n"
+                 << "Point of Interest: "
+                 << "x=" << conf.point_of_interest.x() << ", "
+                 << "y=" << conf.point_of_interest.y() << ", "
+                 << "z=" << conf.point_of_interest.z() << "\n"
+                 << flush;
         }
         return 0;
     }
@@ -189,7 +198,8 @@ int main(int argc, char** argv)
             return 0;
         }
         else if (argc != 5) {
-            cerr << "set expects exactly two more parameters NAME and VALUE" << endl << endl;
+            cerr << "set expects exactly two more parameters NAME and VALUE" << endl
+                 << endl;
             return usage();
         }
 
@@ -238,21 +248,23 @@ int main(int argc, char** argv)
         driver.openURI(uri);
         driver.validateDevice();
         driver.writePeriodicPacketConfiguration("e2", 10);
-        while(true) {
+        while (true) {
             if (driver.processOne()) {
                 auto state = driver.getLastPeriodicUpdate();
-                std::cout << state.rbs.time
-                        << " " << state.filter_state.toString()
-                        << fixed
-                        << " " << setprecision(1) << base::getRoll(state.rbs.orientation) * 180 / M_PI << " "
-                        << " " << setprecision(1) << base::getPitch(state.rbs.orientation) * 180 / M_PI << " "
-                        << " " << setprecision(1) << base::getYaw(state.rbs.orientation) * 180 / M_PI << " "
-                        << " " << setprecision(1) << state.rbs.position.x() << " "
-                        << " " << setprecision(1) << state.rbs.position.y() << " "
-                        << " " << setprecision(1) << state.rbs.position.z() << " "
-                        << " " << setprecision(1) << state.rbs.velocity.x() << " "
-                        << " " << setprecision(1) << state.rbs.velocity.y() << " "
-                        << " " << setprecision(1) << state.rbs.velocity.z() << std::endl;
+                std::cout << state.rbs.time << " " << state.filter_state.toString()
+                          << fixed << " " << setprecision(1)
+                          << base::getRoll(state.rbs.orientation) * 180 / M_PI << " "
+                          << " " << setprecision(1)
+                          << base::getPitch(state.rbs.orientation) * 180 / M_PI << " "
+                          << " " << setprecision(1)
+                          << base::getYaw(state.rbs.orientation) * 180 / M_PI << " "
+                          << " " << setprecision(1) << state.rbs.position.x() << " "
+                          << " " << setprecision(1) << state.rbs.position.y() << " "
+                          << " " << setprecision(1) << state.rbs.position.z() << " "
+                          << " " << setprecision(1) << state.rbs.velocity.x() << " "
+                          << " " << setprecision(1) << state.rbs.velocity.y() << " "
+                          << " " << setprecision(1) << state.rbs.velocity.z()
+                          << std::endl;
             }
 
             usleep(poll_period_usec);
@@ -268,21 +280,20 @@ int main(int argc, char** argv)
         driver.validateDevice();
         driver.writePeriodicPacketConfiguration("e4", 10);
         double const rad2deg = 180.0 / M_PI;
-        while(true) {
+        while (true) {
             if (driver.processOne()) {
                 auto state = driver.getLastPeriodicUpdate();
-                std::cout
-                    << state.magnetic_info.time
-                    << fixed << setprecision(2)
-                    << " " << state.magnetic_info.magnetometers[0]
-                    << " " << state.magnetic_info.magnetometers[1]
-                    << " " << state.magnetic_info.magnetometers[2]
-                    << " " << atan2(state.magnetic_info.magnetometers[2], state.magnetic_info.magnetometers[0]) * rad2deg
-                    << " " << state.magnetic_info.measured_euler_angles[0] * rad2deg
-                    << " " << state.magnetic_info.measured_euler_angles[1] * rad2deg
-                    << " " << state.magnetic_info.measured_euler_angles[2] * rad2deg
-                    << " " << state.magnetic_info.declination.getDeg()
-                    << std::endl;
+                std::cout << state.magnetic_info.time << fixed << setprecision(2) << " "
+                          << state.magnetic_info.magnetometers[0] << " "
+                          << state.magnetic_info.magnetometers[1] << " "
+                          << state.magnetic_info.magnetometers[2] << " "
+                          << atan2(state.magnetic_info.magnetometers[2],
+                                 state.magnetic_info.magnetometers[0]) *
+                                 rad2deg
+                          << " " << state.magnetic_info.measured_euler_angles[0] * rad2deg
+                          << " " << state.magnetic_info.measured_euler_angles[1] * rad2deg
+                          << " " << state.magnetic_info.measured_euler_angles[2] * rad2deg
+                          << " " << state.magnetic_info.declination.getDeg() << std::endl;
             }
 
             usleep(poll_period_usec);
@@ -309,8 +320,8 @@ int main(int argc, char** argv)
         return 0;
     }
     else if (cmd == "find-rate") {
-        int rates[] = { 38400, 57600, 115200, 230400, 0 };
-        for (int i = 0; ; ++i) {
+        int rates[] = {38400, 57600, 115200, 230400, 0};
+        for (int i = 0;; ++i) {
             int r = rates[i];
             if (r == 0) {
                 cerr << "cannot find openIMU on " + uri << endl;
@@ -323,13 +334,13 @@ int main(int argc, char** argv)
                 cout << "found OpenIMU at " << r << " bauds" << endl;
                 break;
             }
-            catch(iodrivers_base::TimeoutError&) {}
+            catch (iodrivers_base::TimeoutError&) {
+            }
         }
         auto info = driver.validateDevice();
 
-        cout
-            << "ID: " << info.device_id << "\n"
-            << "App: " << info.app_version << std::endl;
+        cout << "ID: " << info.device_id << "\n"
+             << "App: " << info.app_version << std::endl;
         return 0;
     }
     else if (cmd == "to-bootloader") {
@@ -349,7 +360,7 @@ int main(int argc, char** argv)
 
         std::vector<uint8_t> firmware;
         string path = argv[3];
-        ifstream file(path, ios::in|ios::binary|ios::ate);
+        ifstream file(path, ios::in | ios::binary | ios::ate);
         if (!file.is_open()) {
             throw std::runtime_error("cannot open " + path + " for reading");
         }
@@ -368,8 +379,7 @@ int main(int argc, char** argv)
                 string bootloader_uri = uri.substr(0, uri.rfind(":")) + ":57600";
                 driver.openURI(bootloader_uri);
                 info = driver.readDeviceInfo();
-                cout << "contacted unit in bootloader mode at "
-                     << bootloader_uri << endl;
+                cout << "contacted unit in bootloader mode at " << bootloader_uri << endl;
                 if (!info.bootloader_mode) {
                     std::cerr << "failed to switch to bootloader mode" << std::endl;
                     return 1;
@@ -389,9 +399,8 @@ int main(int argc, char** argv)
         driver.openURI(uri);
         cout << "\rfirmware update successful" << endl;
         info = driver.readDeviceInfo();
-        cout
-            << "ID: " << info.device_id << "\n"
-            << "App: " << info.app_version << std::endl;
+        cout << "ID: " << info.device_id << "\n"
+             << "App: " << info.app_version << std::endl;
     }
     else if (cmd == "reset") {
         driver.openURI(uri);

--- a/src/MainNMEAPublisher.cpp
+++ b/src/MainNMEAPublisher.cpp
@@ -1,0 +1,48 @@
+#include <imu_aceinna_openimu/Driver.hpp>
+#include <imu_aceinna_openimu/NMEAPublisher.hpp>
+#include <iostream>
+
+using namespace std;
+using namespace imu_aceinna_openimu;
+
+static void usage(ostream& out)
+{
+    out << "imu_aceinna_openimu_nmea_publisher DEVICE_URI FORWARD_URI "
+           "FORWARD_TIMEOUT NMEA_URI\n"
+        << "  forwards data (two-way) between URI1 and URI2, which must both\n"
+        << "  be valid iodrivers_base URIs. In addition, convert IMU data into NMEA "
+           "sentences and forward them to NMEA_URI\n"
+        << "\n"
+        << "  FORWARD_TIMEOOUT defines how long (in milliseconds) the forwarder "
+           "should\n"
+        << "  wait on read before forwarding the data, to avoid unnecessary "
+           "fragmentation\n"
+        << flush;
+}
+
+static const int BUFFER_SIZE = 32768;
+
+int main(int argc, char** argv)
+{
+    if (argc != 5) {
+        usage(argc == 1 ? cout : cerr);
+        return argc == 1 ? 0 : 1;
+    }
+
+    string device_uri = argv[1];
+    string forward_uri = argv[2];
+    base::Time forward_timeout = base::Time::fromMilliseconds(atoi(argv[3]));
+    string nmea_uri = argv[4];
+
+    NMEAPublisher publisher;
+    publisher.openDevice(device_uri);
+    publisher.openForward(forward_uri, forward_timeout);
+    publisher.openNMEA(nmea_uri);
+
+    while (true) {
+        if (!publisher.process(base::Time::fromSeconds(60))) {
+            publisher.configureIMU();
+        }
+    }
+    return 0;
+}

--- a/src/NMEAPublisher.cpp
+++ b/src/NMEAPublisher.cpp
@@ -72,7 +72,7 @@ void NMEAPublisher::publishNMEA(PeriodicUpdate const& update)
     if (base::isUnknown(update.rbs.orientation.w())) {
         return;
     }
-    double heading = update.rbs.getYaw();
+    double heading = -update.rbs.getYaw();
     if (heading < 0) {
         heading += 2 * M_PI;
     }

--- a/src/NMEAPublisher.cpp
+++ b/src/NMEAPublisher.cpp
@@ -82,7 +82,8 @@ void NMEAPublisher::publishNMEA(PeriodicUpdate const& update)
     str << "GPHDT," << fixed << setprecision(1) << heading << ",T";
     uint8_t checksum = computeNMEAChecksum(str.str());
 
-    str << "*" << setw(2) << setfill('0') << hex << static_cast<int>(checksum);
+    str << "*" << setw(2) << setfill('0') << hex << uppercase
+        << static_cast<int>(checksum);
 
     string sentence = "$" + str.str() + "\r\n";
     m_nmea.writePacket(reinterpret_cast<uint8_t const*>(sentence.data()),

--- a/src/NMEAPublisher.cpp
+++ b/src/NMEAPublisher.cpp
@@ -1,0 +1,129 @@
+#include <base/Time.hpp>
+#include <imu_aceinna_openimu/NMEAPublisher.hpp>
+#include <imu_aceinna_openimu/Protocol.hpp>
+#include <iomanip>
+
+using namespace imu_aceinna_openimu;
+using namespace std;
+
+NMEAPublisher::NMEAPublisher()
+{
+    m_buffer.resize(BUFFER_SIZE);
+}
+
+void NMEAPublisher::openDevice(std::string const& uri)
+{
+    m_device.openURI(uri);
+}
+void NMEAPublisher::openForward(std::string const& uri, base::Time const& read_timeout)
+{
+    m_forward_read_timeout = read_timeout;
+    m_forward.openURI(uri);
+}
+void NMEAPublisher::openNMEA(std::string const& uri)
+{
+    m_nmea.openURI(uri);
+}
+
+int NMEAPublisher::forwardToDevice()
+{
+    int size = 0;
+    try {
+        size =
+            m_forward.readRaw(m_buffer.data(), m_buffer.size(), m_forward_read_timeout);
+    }
+    catch (iodrivers_base::TimeoutError&) {
+    }
+
+    if (size != 0) {
+        m_device.writePacket(m_buffer.data(), size);
+    }
+    return size;
+}
+
+pair<bool, PeriodicUpdate> NMEAPublisher::forwardFromDevice()
+{
+    int packet_size = m_device.readPacket(m_buffer.data(), m_buffer.size());
+    m_forward.writePacket(m_buffer.data(), packet_size);
+
+    auto payload = m_buffer.data() + protocol::PAYLOAD_OFFSET;
+    auto payload_size = packet_size - protocol::PACKET_OVERHEAD;
+    if (m_buffer[2] == 'e' && m_buffer[3] == '2') {
+        return make_pair(true, protocol::parseE2Output(payload, payload_size));
+    }
+    else if (m_buffer[2] == 'e' && m_buffer[3] == '4') {
+        return make_pair(true, protocol::parseE4Output(payload, payload_size));
+    }
+
+    return make_pair(false, PeriodicUpdate());
+}
+
+static uint8_t computeNMEAChecksum(string const& str)
+{
+    uint8_t checksum = 0;
+    for (size_t i = 0; i < str.length(); ++i) {
+        checksum ^= str.at(i);
+    }
+    return checksum;
+}
+
+void NMEAPublisher::publishNMEA(PeriodicUpdate const& update)
+{
+    if (base::isUnknown(update.rbs.orientation.w())) {
+        return;
+    }
+    double heading = update.rbs.getYaw();
+    if (heading < 0) {
+        heading += 2 * M_PI;
+    }
+    heading = heading * 180 / M_PI;
+
+    ostringstream str;
+    str << "GPHDT," << fixed << setprecision(1) << heading << ",T";
+    uint8_t checksum = computeNMEAChecksum(str.str());
+
+    str << "*" << setw(2) << setfill('0') << hex << static_cast<int>(checksum);
+
+    string sentence = "$" + str.str() + "\r\n";
+    m_nmea.writePacket(reinterpret_cast<uint8_t const*>(sentence.data()),
+        sentence.length());
+}
+
+bool NMEAPublisher::process(base::Time const& timeout)
+{
+    int device_fd = m_device.getFileDescriptor();
+    int forward_fd = m_forward.getFileDescriptor();
+
+    fd_set set;
+    FD_ZERO(&set);
+    FD_SET(device_fd, &set);
+    FD_SET(forward_fd, &set);
+
+    timeval timeout_spec = {static_cast<time_t>(timeout.toSeconds()),
+        suseconds_t(timeout.toMicroseconds() % 1000000ULL)};
+
+    int select_nfd = std::max(device_fd, forward_fd) + 1;
+    int ret = select(select_nfd, &set, NULL, NULL, &timeout_spec);
+    if (ret < 0 && errno != EINTR)
+        throw iodrivers_base::UnixError("forward(): error in select()");
+    else if (ret == 0)
+        return false;
+
+    if (FD_ISSET(device_fd, &set)) {
+        auto update = forwardFromDevice();
+        if (update.first) {
+            publishNMEA(update.second);
+        }
+    }
+
+    if (FD_ISSET(forward_fd, &set)) {
+        forwardToDevice();
+    }
+
+    return true;
+}
+
+void NMEAPublisher::configureIMU()
+{
+    m_device.writePeriodicPacketConfiguration("e4", 10);
+}

--- a/src/NMEAPublisher.hpp
+++ b/src/NMEAPublisher.hpp
@@ -1,0 +1,52 @@
+#ifndef IMU_ACEINNA_OPENIMU_NMEAPUBLISHER_HPP
+#define IMU_ACEINNA_OPENIMU_NMEAPUBLISHER_HPP
+
+#include <imu_aceinna_openimu/Driver.hpp>
+#include <iodrivers_base/Driver.hpp>
+
+namespace imu_aceinna_openimu {
+    class PeriodicUpdate;
+
+    /** A class that "sits" between the IMU and the "real" driver to convert data
+     * into NMEA sentences and publish them */
+    class NMEAPublisher {
+        static constexpr int32_t BUFFER_SIZE = 32768;
+
+        class RawIODriver : public iodrivers_base::Driver {
+            int extractPacket(uint8_t const* buffer, size_t buffer_size) const
+            {
+                return 0;
+            }
+
+        public:
+            RawIODriver()
+                : Driver(BUFFER_SIZE)
+            {
+            }
+        };
+
+        std::vector<uint8_t> m_buffer;
+
+        Driver m_device;
+        RawIODriver m_forward;
+        base::Time m_forward_read_timeout;
+        RawIODriver m_nmea;
+
+        int forwardToDevice();
+        std::pair<bool, PeriodicUpdate> forwardFromDevice();
+
+    public:
+        NMEAPublisher();
+
+        void openDevice(std::string const& uri);
+        void openForward(std::string const& uri, base::Time const& read_timeout);
+        void openNMEA(std::string const& uri);
+
+        bool process(base::Time const& timeout);
+        void publishNMEA(PeriodicUpdate const& update);
+
+        void configureIMU();
+    };
+}
+
+#endif

--- a/src/PeriodicUpdate.hpp
+++ b/src/PeriodicUpdate.hpp
@@ -1,11 +1,11 @@
 #ifndef IMU_ACEINNA_OPENIMU_PERIODICUPDATE_HPP
 #define IMU_ACEINNA_OPENIMU_PERIODICUPDATE_HPP
 
-#include <base/Float.hpp>
-#include <base/samples/RigidBodyState.hpp>
-#include <base/samples/RigidBodyAcceleration.hpp>
-#include <gps_base/UTMConverter.hpp>
 #include <base/Angle.hpp>
+#include <base/Float.hpp>
+#include <base/samples/RigidBodyAcceleration.hpp>
+#include <base/samples/RigidBodyState.hpp>
+#include <gps_base/UTMConverter.hpp>
 #include <imu_aceinna_openimu/FilterState.hpp>
 #include <imu_aceinna_openimu/MagneticInfo.hpp>
 

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -2,10 +2,10 @@
 #define IMU_ACEINNA_OPENIMU_PROTOCOL_HPP
 
 #include <cstdint>
-#include <string>
 #include <imu_aceinna_openimu/Configuration.hpp>
 #include <imu_aceinna_openimu/PeriodicUpdate.hpp>
 #include <imu_aceinna_openimu/Status.hpp>
+#include <string>
 
 namespace imu_aceinna_openimu {
     namespace protocol {
@@ -22,8 +22,10 @@ namespace imu_aceinna_openimu {
         // Biggest block that can be written when flashing the firmware
         static const int MAX_APP_BLOCK_SIZE = 240;
         // Transformation that rotates by PI the X axis. Usefull for NED/NWU convertions
-        static const base::Matrix3d RotNED2NWU(base::AngleAxisd(M_PI, base::Vector3d::UnitX()));
-        static const base::Matrix3d RotNWU2NED(base::AngleAxisd(-M_PI, base::Vector3d::UnitX()));
+        static const base::Matrix3d RotNED2NWU(
+            base::AngleAxisd(M_PI, base::Vector3d::UnitX()));
+        static const base::Matrix3d RotNWU2NED(
+            base::AngleAxisd(-M_PI, base::Vector3d::UnitX()));
 
         enum WriteStatus {
             WRITE_STATUS_OK = 0,
@@ -48,8 +50,10 @@ namespace imu_aceinna_openimu {
 
         /** Generic packet formatting
          */
-        uint8_t* formatPacket(uint8_t* buffer, char const* code,
-                              uint8_t const* payload, int size);
+        uint8_t* formatPacket(uint8_t* buffer,
+            char const* code,
+            uint8_t const* payload,
+            int size);
 
         /** Writes a device info query (pG) to the given buffer
          */
@@ -78,12 +82,13 @@ namespace imu_aceinna_openimu {
          * T can only be int64_t and std::string. Any other type will fail at
          * linking time
          */
-        template<typename T>
+        template <typename T>
         uint8_t* writeConfiguration(uint8_t* buffer, int index, T value);
 
         /** Write an orientation configuration parameters */
-        uint8_t* writeConfiguration(uint8_t* buffer, int index,
-                                    Configuration::Orientation axes);
+        uint8_t* writeConfiguration(uint8_t* buffer,
+            int index,
+            Configuration::Orientation axes);
 
         /** Parse the status from the configuration write reply */
         WriteStatus parseWriteConfigurationStatus(uint8_t* buffer, int bufferSize);
@@ -99,7 +104,7 @@ namespace imu_aceinna_openimu {
          * T can only be int64_t and std::string. Any other type will fail at
          * linking time
          */
-        template<typename T>
+        template <typename T>
         T parseConfigurationParameter(uint8_t* buffer, int bufferSize, int expectedIndex);
 
         /** Restore default configuration and save it to flash
@@ -124,8 +129,10 @@ namespace imu_aceinna_openimu {
 
         /** Write an app block
          */
-        uint8_t* queryAppBlockWrite(uint8_t* buffer, uint32_t address,
-                                    uint8_t const* blockData, int blockSize);
+        uint8_t* queryAppBlockWrite(uint8_t* buffer,
+            uint32_t address,
+            uint8_t const* blockData,
+            int blockSize);
 
         /** Query the unit status (gS)
          */
@@ -135,11 +142,9 @@ namespace imu_aceinna_openimu {
          */
         Status parseStatus(uint8_t const* buffer, int size);
 
-        template<typename T>
-        T valueNED2NWU(T neu);
+        template <typename T> T valueNED2NWU(T neu);
 
-        template<typename H>
-        H covarianceNED2NWU(H neu);
+        template <typename H> H covarianceNED2NWU(H neu);
 
         /** Parse the stock INS output message (e2) */
         PeriodicUpdate parseE2Output(uint8_t const* buffer, int bufferSize);

--- a/src/Status.hpp
+++ b/src/Status.hpp
@@ -1,8 +1,8 @@
 #ifndef IMU_ACEINNA_OPENIMU_STATUS_HPP
 #define IMU_ACEINNA_OPENIMU_STATUS_HPP
 
-#include <base/Time.hpp>
 #include <base/Temperature.hpp>
+#include <base/Time.hpp>
 #include <imu_aceinna_openimu/FilterState.hpp>
 
 namespace imu_aceinna_openimu {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
 rock_gtest(test_suite suite.cpp
    test_Protocol.cpp test_Driver.cpp test_Configuration.cpp
    DEPS imu_aceinna_openimu)
+
+rock_gtest(test_NMEAPublisher suite.cpp
+   test_NMEAPublisher.cpp ../src/NMEAPublisher.cpp
+   DEPS imu_aceinna_openimu)

--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,7 +1,8 @@
 // Do NOT add anything to this file
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/test_Configuration.cpp
+++ b/test/test_Configuration.cpp
@@ -3,50 +3,64 @@
 
 using namespace imu_aceinna_openimu;
 
-struct ConfigurationOrientationTest : public ::testing::Test {
-};
+struct ConfigurationOrientationTest : public ::testing::Test {};
 
-TEST_F(ConfigurationOrientationTest, it_is_equal_if_all_three_fields_are) {
-    Configuration::Orientation conf0(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
-    Configuration::Orientation conf1(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
+TEST_F(ConfigurationOrientationTest, it_is_equal_if_all_three_fields_are)
+{
+    Configuration::Orientation conf0(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
+    Configuration::Orientation conf1(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
     ASSERT_EQ(conf0, conf1);
     ASSERT_TRUE(!(conf0 != conf1));
 }
 
-TEST_F(ConfigurationOrientationTest, it_is_not_equal_if_forward_differs) {
-    Configuration::Orientation conf0(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
-    Configuration::Orientation conf1(
-        ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
+TEST_F(ConfigurationOrientationTest, it_is_not_equal_if_forward_differs)
+{
+    Configuration::Orientation conf0(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
+    Configuration::Orientation conf1(ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
     ASSERT_NE(conf0, conf1);
     ASSERT_TRUE(conf0 != conf1);
 }
 
-TEST_F(ConfigurationOrientationTest, it_is_not_equal_if_right_differs) {
-    Configuration::Orientation conf0(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
-    Configuration::Orientation conf1(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Z);
+TEST_F(ConfigurationOrientationTest, it_is_not_equal_if_right_differs)
+{
+    Configuration::Orientation conf0(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
+    Configuration::Orientation conf1(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Z);
     ASSERT_NE(conf0, conf1);
     ASSERT_TRUE(conf0 != conf1);
 }
 
-TEST_F(ConfigurationOrientationTest, it_is_not_equal_if_down_differs) {
-    Configuration::Orientation conf0(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
-    Configuration::Orientation conf1(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Y);
+TEST_F(ConfigurationOrientationTest, it_is_not_equal_if_down_differs)
+{
+    Configuration::Orientation conf0(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
+    Configuration::Orientation conf1(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Y);
     ASSERT_NE(conf0, conf1);
     ASSERT_TRUE(conf0 != conf1);
 }
 
-TEST_F(ConfigurationOrientationTest, it_formats_itself_to_string) {
-    Configuration::Orientation confplus(
-        ORIENTATION_AXIS_PLUS_X, ORIENTATION_AXIS_PLUS_Y, ORIENTATION_AXIS_PLUS_Z);
+TEST_F(ConfigurationOrientationTest, it_formats_itself_to_string)
+{
+    Configuration::Orientation confplus(ORIENTATION_AXIS_PLUS_X,
+        ORIENTATION_AXIS_PLUS_Y,
+        ORIENTATION_AXIS_PLUS_Z);
     ASSERT_EQ("+X+Y+Z", to_string(confplus));
-    Configuration::Orientation confminus(
-        ORIENTATION_AXIS_MINUS_X, ORIENTATION_AXIS_MINUS_Y, ORIENTATION_AXIS_MINUS_Z);
+    Configuration::Orientation confminus(ORIENTATION_AXIS_MINUS_X,
+        ORIENTATION_AXIS_MINUS_Y,
+        ORIENTATION_AXIS_MINUS_Z);
     ASSERT_EQ("-X-Y-Z", to_string(confminus));
 }

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -6,107 +6,208 @@
 using namespace std;
 using namespace imu_aceinna_openimu;
 
-#define ASSERT_THROW_MESSAGE(code, exception, message) \
-    ASSERT_THROW({ \
-        try { code; } \
-        catch(exception& e) { \
-            ASSERT_EQ(message, string(e.what())); \
-            throw; \
-        } \
-    }, exception)
+#define ASSERT_THROW_MESSAGE(code, exception, message)                                   \
+    ASSERT_THROW(                                                                        \
+        {                                                                                \
+            try {                                                                        \
+                code;                                                                    \
+            }                                                                            \
+            catch (exception & e) {                                                      \
+                ASSERT_EQ(message, string(e.what()));                                    \
+                throw;                                                                   \
+            }                                                                            \
+        },                                                                               \
+        exception)
 
 struct DriverTest : public ::testing::Test, iodrivers_base::Fixture<Driver> {
-    void openDriver() {
+    void openDriver()
+    {
         driver.openURI("test://");
     }
 };
 
-TEST_F(DriverTest, it_queries_the_device_description_on_open) {
+TEST_F(DriverTest, it_queries_the_device_description_on_open)
+{
     driver.openURI("test://");
 
     IODRIVERS_BASE_MOCK();
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'p', 'G', 0, 0x5d, 0x5f },
-        vector<uint8_t>{ 0x55, 0x55, 'p', 'G', 4, 'a', 'b', 'c', 'd', 0x1f, 0x72 });
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'g', 'V', 0, 0xab, 0xee },
-        vector<uint8_t>{ 0x55, 0x55, 'g', 'V', 5, 'I', 'N', 'S', 'T', 'W', 0x39, 0x0f });
+    EXPECT_REPLY(vector<uint8_t>{0x55, 0x55, 'p', 'G', 0, 0x5d, 0x5f},
+        vector<uint8_t>{0x55, 0x55, 'p', 'G', 4, 'a', 'b', 'c', 'd', 0x1f, 0x72});
+    EXPECT_REPLY(vector<uint8_t>{0x55, 0x55, 'g', 'V', 0, 0xab, 0xee},
+        vector<uint8_t>{0x55, 0x55, 'g', 'V', 5, 'I', 'N', 'S', 'T', 'W', 0x39, 0x0f});
     auto info = driver.readDeviceInfo();
     ASSERT_EQ("abcd", info.device_id);
     ASSERT_EQ("INSTW", info.app_version);
 }
 
-TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_not_a_4_byte_value) {
+TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_not_a_4_byte_value)
+{
     IODRIVERS_BASE_MOCK();
     openDriver();
 
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 12, 2, 0, 0, 0,
-                         0x20, 0x10, 0, 0, 0, 0, 0, 0, 0xA2, 0x73 },
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 3, 0xff, 0xff, 0xff, 0x6b, 0x21 });
-    ASSERT_THROW_MESSAGE(
-        driver.writeConfiguration<int64_t>(2, 0x1020, true),
+    EXPECT_REPLY(vector<uint8_t>{0x55,
+                     0x55,
+                     'u',
+                     'P',
+                     12,
+                     2,
+                     0,
+                     0,
+                     0,
+                     0x20,
+                     0x10,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0xA2,
+                     0x73},
+        vector<uint8_t>{0x55, 0x55, 'u', 'P', 3, 0xff, 0xff, 0xff, 0x6b, 0x21});
+    ASSERT_THROW_MESSAGE(driver.writeConfiguration<int64_t>(2, 0x1020, true),
         std::invalid_argument,
         "unexpected reply size for uP (write configuration parameter), "
         "expected 4 bytes, got 3");
 }
 
-TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_INVALID_PARAM) {
+TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_INVALID_PARAM)
+{
     IODRIVERS_BASE_MOCK();
     openDriver();
 
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 12, 2, 0, 0, 0,
-                         0x20, 0x10, 0, 0, 0, 0, 0, 0, 0xA2, 0x73 },
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 4, 0xff, 0xff, 0xff, 0xff, 0x85, 0xe9 });
-    ASSERT_THROW_MESSAGE(
-        driver.writeConfiguration<int64_t>(2, 0x1020, true),
+    EXPECT_REPLY(vector<uint8_t>{0x55,
+                     0x55,
+                     'u',
+                     'P',
+                     12,
+                     2,
+                     0,
+                     0,
+                     0,
+                     0x20,
+                     0x10,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0xA2,
+                     0x73},
+        vector<uint8_t>{0x55, 0x55, 'u', 'P', 4, 0xff, 0xff, 0xff, 0xff, 0x85, 0xe9});
+    ASSERT_THROW_MESSAGE(driver.writeConfiguration<int64_t>(2, 0x1020, true),
         ConfigurationWriteFailed,
         "writing configuration parameter 2 failed: invalid parameter index");
 }
 
-TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_INVALID_VALUE) {
+TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_INVALID_VALUE)
+{
     IODRIVERS_BASE_MOCK();
     openDriver();
 
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 12, 2, 0, 0, 0,
-                         0x20, 0x10, 0, 0, 0, 0, 0, 0, 0xA2, 0x73 },
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 4, 0xfe, 0xff, 0xff, 0xff, 0xf3, 0x5d });
-    ASSERT_THROW_MESSAGE(
-        driver.writeConfiguration<int64_t>(2, 0x1020, true),
+    EXPECT_REPLY(vector<uint8_t>{0x55,
+                     0x55,
+                     'u',
+                     'P',
+                     12,
+                     2,
+                     0,
+                     0,
+                     0,
+                     0x20,
+                     0x10,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0xA2,
+                     0x73},
+        vector<uint8_t>{0x55, 0x55, 'u', 'P', 4, 0xfe, 0xff, 0xff, 0xff, 0xf3, 0x5d});
+    ASSERT_THROW_MESSAGE(driver.writeConfiguration<int64_t>(2, 0x1020, true),
         ConfigurationWriteFailed,
         "writing configuration parameter 2 failed: invalid value 4128");
 }
 
-TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_an_unknown_failure) {
+TEST_F(DriverTest, it_raises_if_the_parameter_write_result_is_an_unknown_failure)
+{
     IODRIVERS_BASE_MOCK();
     openDriver();
 
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 12, 2, 0, 0, 0,
-                         0x20, 0x10, 0, 0, 0, 0, 0, 0, 0xA2, 0x73 },
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 4, 0xfe, 0xff, 0x10, 0xff, 0xf3, 0xd1 });
-    ASSERT_THROW_MESSAGE(
-        driver.writeConfiguration<int64_t>(2, 0x1020, true),
+    EXPECT_REPLY(vector<uint8_t>{0x55,
+                     0x55,
+                     'u',
+                     'P',
+                     12,
+                     2,
+                     0,
+                     0,
+                     0,
+                     0x20,
+                     0x10,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0xA2,
+                     0x73},
+        vector<uint8_t>{0x55, 0x55, 'u', 'P', 4, 0xfe, 0xff, 0x10, 0xff, 0xf3, 0xd1});
+    ASSERT_THROW_MESSAGE(driver.writeConfiguration<int64_t>(2, 0x1020, true),
         ConfigurationWriteFailed,
         "writing configuration parameter 2 failed: unknown error");
 }
 
-TEST_F(DriverTest, it_raises_if_the_property_actual_value_differs_from_the_written_if_validate_is_true) {
+TEST_F(DriverTest,
+    it_raises_if_the_property_actual_value_differs_from_the_written_if_validate_is_true)
+{
     IODRIVERS_BASE_MOCK();
     openDriver();
 
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 12, 2, 0, 0, 0,
-                         0x20, 0x10, 0, 0, 0, 0, 0, 0, 0xA2, 0x73 },
-        vector<uint8_t>{ 0x55, 0x55, 'u', 'P', 4, 0, 0, 0, 0, 0x1c, 0x26 });
-    EXPECT_REPLY(
-        vector<uint8_t>{ 0x55, 0x55, 'g', 'P', 4, 2, 0, 0, 0, 0xa6, 0xd6 },
-        vector<uint8_t>{ 0x55, 0x55, 'g', 'P', 12, 2, 0, 0, 0,
-                         0x20, 0x11, 0, 0, 0, 0, 0, 0, 0x19, 0x41 });
-    ASSERT_THROW_MESSAGE(
-        driver.writeConfiguration<int64_t>(2, 0x1020, true),
+    EXPECT_REPLY(vector<uint8_t>{0x55,
+                     0x55,
+                     'u',
+                     'P',
+                     12,
+                     2,
+                     0,
+                     0,
+                     0,
+                     0x20,
+                     0x10,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0xA2,
+                     0x73},
+        vector<uint8_t>{0x55, 0x55, 'u', 'P', 4, 0, 0, 0, 0, 0x1c, 0x26});
+    EXPECT_REPLY(vector<uint8_t>{0x55, 0x55, 'g', 'P', 4, 2, 0, 0, 0, 0xa6, 0xd6},
+        vector<uint8_t>{0x55,
+            0x55,
+            'g',
+            'P',
+            12,
+            2,
+            0,
+            0,
+            0,
+            0x20,
+            0x11,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0x19,
+            0x41});
+    ASSERT_THROW_MESSAGE(driver.writeConfiguration<int64_t>(2, 0x1020, true),
         ConfigurationWriteFailed,
         "writing configuration parameter 2 failed. "
         "Current property value is 4384, expected 4128");

--- a/test/test_NMEAPublisher.cpp
+++ b/test/test_NMEAPublisher.cpp
@@ -100,7 +100,7 @@ TEST_F(NMEAPublisherTest, it_generates_valid_NMEA_messages_based_on_a_e4_message
     int size = nmea.readRaw(buffer.data(), buffer.size(), Time::fromMilliseconds(100));
     string msg(reinterpret_cast<char const*>(buffer.data()),
         reinterpret_cast<char const*>(buffer.data()) + size);
-    ASSERT_EQ("$GPHDT,211.3,T*34\r\n", msg);
+    ASSERT_EQ("$GPHDT,148.7,T*3f\r\n", msg);
 }
 
 TEST_F(NMEAPublisherTest, it_ignores_an_invalid_orientation)

--- a/test/test_NMEAPublisher.cpp
+++ b/test/test_NMEAPublisher.cpp
@@ -100,7 +100,7 @@ TEST_F(NMEAPublisherTest, it_generates_valid_NMEA_messages_based_on_a_e4_message
     int size = nmea.readRaw(buffer.data(), buffer.size(), Time::fromMilliseconds(100));
     string msg(reinterpret_cast<char const*>(buffer.data()),
         reinterpret_cast<char const*>(buffer.data()) + size);
-    ASSERT_EQ("$GPHDT,148.7,T*3f\r\n", msg);
+    ASSERT_EQ("$GPHDT,148.7,T*3F\r\n", msg);
 }
 
 TEST_F(NMEAPublisherTest, it_ignores_an_invalid_orientation)

--- a/test/test_NMEAPublisher.cpp
+++ b/test/test_NMEAPublisher.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+#include <imu_aceinna_openimu/NMEAPublisher.hpp>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+
+using namespace imu_aceinna_openimu;
+using namespace std;
+using base::Time;
+
+class RawIODriver : public iodrivers_base::Driver {
+    int extractPacket(uint8_t const* buffer, size_t buffer_size) const
+    {
+        return 0;
+    }
+
+public:
+    RawIODriver()
+        : Driver(256)
+    {
+    }
+};
+
+struct NMEAPublisherTest : public ::testing::Test {
+    NMEAPublisher publisher;
+    RawIODriver device;
+    RawIODriver forward;
+    RawIODriver nmea;
+
+    NMEAPublisherTest()
+    {
+        auto fds = openSocketPair();
+        publisher.openDevice("fd://" + to_string(fds.first));
+        device.openURI("fd://" + to_string(fds.second));
+
+        fds = openSocketPair();
+        publisher.openForward("fd://" + to_string(fds.first), Time::fromMilliseconds(10));
+        forward.openURI("fd://" + to_string(fds.second));
+
+        fds = openSocketPair();
+        publisher.openNMEA("fd://" + to_string(fds.first));
+        nmea.openURI("fd://" + to_string(fds.second));
+    }
+
+    pair<int, int> openSocketPair()
+    {
+        int fds[2];
+        if (socketpair(AF_UNIX, SOCK_DGRAM, 0, fds) == -1) {
+            throw iodrivers_base::UnixError("cannot create socket pair");
+        }
+        return make_pair(fds[0], fds[1]);
+    }
+};
+
+TEST_F(NMEAPublisherTest, it_forwards_messages_from_the_device_to_the_forward)
+{
+    vector<uint8_t> msg{0x55, 0x55, 'p', 'G', 0, 0x5d, 0x5f};
+    device.writePacket(msg.data(), msg.size());
+    publisher.process(Time::fromSeconds(1));
+    vector<uint8_t> buffer(32768, 0);
+    ASSERT_EQ(msg.size(),
+        forward.readRaw(buffer.data(), msg.size(), Time::fromSeconds(1)));
+    ASSERT_EQ(msg, vector<uint8_t>(buffer.begin(), buffer.begin() + msg.size()));
+    ASSERT_EQ(0, nmea.readRaw(buffer.data(), buffer.size(), Time::fromMilliseconds(100)));
+}
+
+TEST_F(NMEAPublisherTest, it_forwards_messages_from_the_forward_to_the_device)
+{
+    vector<uint8_t> msg{1, 2, 3, 4, 5};
+    forward.writePacket(msg.data(), msg.size());
+    publisher.process(Time::fromSeconds(1));
+    vector<uint8_t> buffer(32768, 0);
+    ASSERT_EQ(msg.size(),
+        device.readRaw(buffer.data(), msg.size(), Time::fromSeconds(1)));
+    ASSERT_EQ(msg, vector<uint8_t>(buffer.begin(), buffer.begin() + msg.size()));
+    ASSERT_EQ(0, nmea.readRaw(buffer.data(), buffer.size(), Time::fromMilliseconds(100)));
+}
+
+TEST_F(NMEAPublisherTest, it_generates_valid_NMEA_messages_based_on_a_e4_message)
+{
+    // clang-format off
+    // Sample taken from an IMU log. Yaw = 91.6
+    // Log ID: 090aeb8eadaebeb3f36c992967ca, Time: 1665004477.344012
+    // Q_nwu=-0.19867369532585144 -0.18287518620491025 0.67453211545944214 0.68708944320678711
+    vector<uint8_t> e4{85, 85, 101, 52, 97, 97, 207, 31, 0, 4, 162, 67, 59, 62,
+        30, 113, 75, 190, 24, 229, 47, 191, 35, 174, 44, 63, 18, 182, 130, 191, 16,
+        92, 201, 62, 74, 168, 105, 191, 195, 107, 147, 189, 64, 213, 230, 59, 126,
+        255, 20, 189, 155, 52, 130, 155, 216, 234, 54, 192, 78, 25, 210, 29, 218,
+        149, 69, 192, 0, 0, 128, 227, 217, 241, 252, 191, 109, 64, 26, 190, 59, 223,
+        15, 62, 111, 236, 168, 188, 102, 197, 202, 191, 217, 219, 180, 60, 13, 196,
+        37, 64, 169, 31, 203, 190, 64, 134};
+    // clang-format on
+
+    device.writePacket(e4.data(), e4.size());
+    publisher.process(Time::fromSeconds(1));
+    vector<uint8_t> buffer(32768, 0);
+    ASSERT_EQ(e4.size(), forward.readRaw(buffer.data(), e4.size(), Time::fromSeconds(1)));
+    ASSERT_EQ(e4, vector<uint8_t>(buffer.begin(), buffer.begin() + e4.size()));
+
+    int size = nmea.readRaw(buffer.data(), buffer.size(), Time::fromMilliseconds(100));
+    string msg(reinterpret_cast<char const*>(buffer.data()),
+        reinterpret_cast<char const*>(buffer.data()) + size);
+    ASSERT_EQ("$GPHDT,211.3,T*34\r\n", msg);
+}
+
+TEST_F(NMEAPublisherTest, it_ignores_an_invalid_orientation)
+{
+    PeriodicUpdate update;
+    update.rbs = base::samples::RigidBodyState::invalid();
+    publisher.publishNMEA(update);
+
+    uint8_t buffer[32768];
+    ASSERT_EQ(0, nmea.readRaw(buffer, 32768, Time::fromMilliseconds(100)));
+}

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <imu_aceinna_openimu/Protocol.hpp>
 
 using namespace std;
@@ -7,46 +7,57 @@ using namespace imu_aceinna_openimu::protocol;
 using testing::ElementsAre;
 using testing::ElementsAreArray;
 
-#define ASSERT_THROW_MESSAGE(code, exception, message) \
-    ASSERT_THROW({ \
-        try { code; } \
-        catch (exception& e) { \
-            ASSERT_EQ(message, string(e.what())); \
-            throw; \
-        } \
-    }, exception)
+#define ASSERT_THROW_MESSAGE(code, exception, message)                                   \
+    ASSERT_THROW(                                                                        \
+        {                                                                                \
+            try {                                                                        \
+                code;                                                                    \
+            }                                                                            \
+            catch (exception & e) {                                                      \
+                ASSERT_EQ(message, string(e.what()));                                    \
+                throw;                                                                   \
+            }                                                                            \
+        },                                                                               \
+        exception)
 
 struct ProtocolTest : public ::testing::Test {
     std::vector<uint8_t> buffer;
 
-    ProtocolTest() {
+    ProtocolTest()
+    {
         buffer.resize(256, 0);
     }
 };
 
-TEST_F(ProtocolTest, it_waits_for_more_bytes_if_the_buffer_is_too_small) {
+TEST_F(ProtocolTest, it_waits_for_more_bytes_if_the_buffer_is_too_small)
+{
     ASSERT_EQ(0, extractPacket(&buffer[0], 4));
 }
-TEST_F(ProtocolTest, it_finds_a_packet_start_within_the_packet) {
+TEST_F(ProtocolTest, it_finds_a_packet_start_within_the_packet)
+{
     buffer[5] = PACKET_START_MARKER;
     buffer[6] = PACKET_START_MARKER;
     ASSERT_EQ(-5, extractPacket(&buffer[0], 9));
 }
-TEST_F(ProtocolTest, it_handles_a_start_byte_at_the_very_end_of_the_buffer) {
+TEST_F(ProtocolTest, it_handles_a_start_byte_at_the_very_end_of_the_buffer)
+{
     buffer[9] = PACKET_START_MARKER;
     ASSERT_EQ(-9, extractPacket(&buffer[0], 10));
 }
-TEST_F(ProtocolTest, it_rejects_a_packet_with_an_invalid_CRC) {
+TEST_F(ProtocolTest, it_rejects_a_packet_with_an_invalid_CRC)
+{
     buffer[0] = PACKET_START_MARKER;
     buffer[1] = PACKET_START_MARKER;
     ASSERT_EQ(-1, extractPacket(&buffer[0], 10));
 }
-TEST_F(ProtocolTest, it_accepts_a_packet_that_starts_at_zero_and_has_a_valid_CRC) {
-    buffer = { PACKET_START_MARKER, PACKET_START_MARKER, 'p', 'G', 0, 0x5d, 0x5f };
+TEST_F(ProtocolTest, it_accepts_a_packet_that_starts_at_zero_and_has_a_valid_CRC)
+{
+    buffer = {PACKET_START_MARKER, PACKET_START_MARKER, 'p', 'G', 0, 0x5d, 0x5f};
     ASSERT_EQ(7, extractPacket(&buffer[0], 10));
 }
 
-TEST_F(ProtocolTest, it_formats_a_device_id_query) {
+TEST_F(ProtocolTest, it_formats_a_device_id_query)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     auto packetEnd = queryDeviceID(&buffer[0]);
 
@@ -54,13 +65,15 @@ TEST_F(ProtocolTest, it_formats_a_device_id_query) {
         ElementsAre(PACKET_START_MARKER, PACKET_START_MARKER, 'p', 'G', 0, 0x5d, 0x5f));
 }
 
-TEST_F(ProtocolTest, it_parses_a_device_id_response) {
-    std::vector<uint8_t> buffer = { 'a', 'b', 'C', 'd' };
+TEST_F(ProtocolTest, it_parses_a_device_id_response)
+{
+    std::vector<uint8_t> buffer = {'a', 'b', 'C', 'd'};
 
     ASSERT_EQ("abCd", parseDeviceID(&buffer[0], 4));
 }
 
-TEST_F(ProtocolTest, it_formats_an_app_version_query) {
+TEST_F(ProtocolTest, it_formats_an_app_version_query)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     auto packetEnd = queryAppVersion(&buffer[0]);
 
@@ -68,13 +81,15 @@ TEST_F(ProtocolTest, it_formats_an_app_version_query) {
         ElementsAre(PACKET_START_MARKER, PACKET_START_MARKER, 'g', 'V', 0, 0xab, 0xee));
 }
 
-TEST_F(ProtocolTest, it_parses_an_app_version_response) {
-    std::vector<uint8_t> buffer = { 'a', 'b', 'C', 'd' };
+TEST_F(ProtocolTest, it_parses_an_app_version_response)
+{
+    std::vector<uint8_t> buffer = {'a', 'b', 'C', 'd'};
 
     ASSERT_EQ("abCd", parseAppVersion(&buffer[0], 4));
 }
 
-TEST_F(ProtocolTest, it_formats_a_configuration_query) {
+TEST_F(ProtocolTest, it_formats_a_configuration_query)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     auto packetEnd = queryConfiguration(&buffer[0]);
 
@@ -82,7 +97,8 @@ TEST_F(ProtocolTest, it_formats_a_configuration_query) {
         ElementsAre(PACKET_START_MARKER, PACKET_START_MARKER, 'g', 'A', 0, 0x31, 0x0A));
 }
 
-TEST_F(ProtocolTest, it_decodes_an_orientation_string) {
+TEST_F(ProtocolTest, it_decodes_an_orientation_string)
+{
     auto orientation = decodeOrientationString("+X+Y+Z");
     ASSERT_EQ(imu_aceinna_openimu::ORIENTATION_AXIS_PLUS_X, orientation.forward);
     ASSERT_EQ(imu_aceinna_openimu::ORIENTATION_AXIS_PLUS_Y, orientation.right);
@@ -93,28 +109,169 @@ TEST_F(ProtocolTest, it_decodes_an_orientation_string) {
     ASSERT_EQ(imu_aceinna_openimu::ORIENTATION_AXIS_MINUS_X, orientation.down);
 }
 
-TEST_F(ProtocolTest, it_parses_a_configuration_response) {
+TEST_F(ProtocolTest, it_parses_a_configuration_response)
+{
     std::vector<uint8_t> buffer = {
-        1, 0, 0, 0, 0, 0, 0, 0, // Data CRC
-        2, 0, 0, 0, 0, 0, 0, 0, // Data Size
-        3, 0, 0, 0, 0, 0, 0, 0, // Baud Rate
-        'g', 'A', ' ', ' ', ' ', ' ', ' ', ' ', // Periodic Packet Type
-        4, 0, 0, 0, 0, 0, 0, 0, // Periodic Packet Rate
-        5, 0, 0, 0, 0, 0, 0, 0, // Accel low-pass filter
-        6, 0, 0, 0, 0, 0, 0, 0, // Rate low-pass filter
-        '+', 'X', '-', 'Y', '+', 'Z', ' ', ' ', // Orientation
-        10, 0, 0, 0, 0, 0, 0, 0, // GPS Baudrate
-        1, 0, 0, 0, 0, 0, 0, 0, // GPS Protocol
-        0, 0, 0, 0, 0, 0, 0x1C, 0x40, // Hard Iron X
-        0, 0, 0, 0, 0, 0, 0x20, 0x40, // Hard Iron Y
-        0, 0, 0, 0, 0, 0, 0x22, 0x40, // Soft Iron Ratio
-        0, 0, 0, 0, 0, 0, 0x24, 0x40, // Soft Iron Angle
-        0, 0, 0, 0, 0, 0, 0xf0, 0x3f, // Lever Arm X
-        0, 0, 0, 0, 0, 0, 0x00, 0x40, // Lever Arm Y
-        0, 0, 0, 0, 0, 0, 0x08, 0x40, // Lever Arm Z
-        0, 0, 0, 0, 0, 0, 0x10, 0x40, // Point of Interest X
-        0, 0, 0, 0, 0, 0, 0x14, 0x40, // Point of Interest Y
-        0, 0, 0, 0, 0, 0, 0x18, 0x40, // Point of Interest Z
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // Data CRC
+        2,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // Data Size
+        3,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // Baud Rate
+        'g',
+        'A',
+        ' ',
+        ' ',
+        ' ',
+        ' ',
+        ' ',
+        ' ', // Periodic Packet Type
+        4,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // Periodic Packet Rate
+        5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // Accel low-pass filter
+        6,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // Rate low-pass filter
+        '+',
+        'X',
+        '-',
+        'Y',
+        '+',
+        'Z',
+        ' ',
+        ' ', // Orientation
+        10,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // GPS Baudrate
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // GPS Protocol
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x1C,
+        0x40, // Hard Iron X
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x20,
+        0x40, // Hard Iron Y
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x22,
+        0x40, // Soft Iron Ratio
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x24,
+        0x40, // Soft Iron Angle
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0xf0,
+        0x3f, // Lever Arm X
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x00,
+        0x40, // Lever Arm Y
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x08,
+        0x40, // Lever Arm Z
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x10,
+        0x40, // Point of Interest X
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x14,
+        0x40, // Point of Interest Y
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x18,
+        0x40, // Point of Interest Z
     };
 
     auto conf = parseConfiguration(&buffer[0], buffer.size());
@@ -139,168 +296,240 @@ TEST_F(ProtocolTest, it_parses_a_configuration_response) {
     ASSERT_FLOAT_EQ(6, conf.point_of_interest.z());
 }
 
-TEST_F(ProtocolTest, it_raises_if_configuration_buffer_is_smaller_than_the_expected_struct) {
+TEST_F(ProtocolTest,
+    it_raises_if_configuration_buffer_is_smaller_than_the_expected_struct)
+{
     ASSERT_THROW(parseConfiguration(nullptr, 55), std::invalid_argument);
 }
 
-TEST_F(ProtocolTest, it_formats_a_configuration_write_for_an_integer_type) {
+TEST_F(ProtocolTest, it_formats_a_configuration_write_for_an_integer_type)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     int16_t value = 0x1020;
     auto packetEnd = writeConfiguration<int64_t>(&buffer[0], 2, value);
 
-    uint8_t expected[] = {
-        PACKET_START_MARKER, PACKET_START_MARKER, 'u', 'P', 12,
-        2, 0, 0, 0,
-        0x20, 0x10, 0, 0, 0, 0, 0, 0,
-        0xA2, 0x73
-    };
-    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd),
-        ElementsAreArray(expected));
+    uint8_t expected[] = {PACKET_START_MARKER,
+        PACKET_START_MARKER,
+        'u',
+        'P',
+        12,
+        2,
+        0,
+        0,
+        0,
+        0x20,
+        0x10,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0xA2,
+        0x73};
+    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd), ElementsAreArray(expected));
 }
 
-TEST_F(ProtocolTest, it_formats_a_configuration_write_for_a_string) {
+TEST_F(ProtocolTest, it_formats_a_configuration_write_for_a_string)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     string value = "abcdefgh";
     auto packetEnd = writeConfiguration(&buffer[0], 2, value);
 
-    uint8_t expected[] = {
-        PACKET_START_MARKER, PACKET_START_MARKER, 'u', 'P', 12,
-        2, 0, 0, 0,
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
-        0x45, 0x9f
-    };
-    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd),
-        ElementsAreArray(expected));
+    uint8_t expected[] = {PACKET_START_MARKER,
+        PACKET_START_MARKER,
+        'u',
+        'P',
+        12,
+        2,
+        0,
+        0,
+        0,
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        'f',
+        'g',
+        'h',
+        0x45,
+        0x9f};
+    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd), ElementsAreArray(expected));
 }
 
-TEST_F(ProtocolTest, it_pads_a_string_smaller_than_8_bytes_with_zeros) {
+TEST_F(ProtocolTest, it_pads_a_string_smaller_than_8_bytes_with_zeros)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     string value = "abcde";
     auto packetEnd = writeConfiguration(&buffer[0], 2, value);
 
-    uint8_t expected[] = {
-        PACKET_START_MARKER, PACKET_START_MARKER, 'u', 'P', 12,
-        2, 0, 0, 0,
-        'a', 'b', 'c', 'd', 'e', 0, 0, 0,
-        0x13, 0x47
-    };
+    uint8_t expected[] = {PACKET_START_MARKER,
+        PACKET_START_MARKER,
+        'u',
+        'P',
+        12,
+        2,
+        0,
+        0,
+        0,
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        0,
+        0,
+        0,
+        0x13,
+        0x47};
 
-    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd),
-        ElementsAreArray(expected));
+    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd), ElementsAreArray(expected));
 }
 
-TEST_F(ProtocolTest, it_throws_if_the_string_is_longer_than_8_bytes) {
+TEST_F(ProtocolTest, it_throws_if_the_string_is_longer_than_8_bytes)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     string value = "abcdefghijk";
     ASSERT_THROW(writeConfiguration(&buffer[0], 2, value), std::invalid_argument);
 }
 
-TEST_F(ProtocolTest, it_formats_a_configuration_write_for_an_orientation) {
+TEST_F(ProtocolTest, it_formats_a_configuration_write_for_an_orientation)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     imu_aceinna_openimu::Configuration::Orientation value = {
         imu_aceinna_openimu::ORIENTATION_AXIS_PLUS_Y,
         imu_aceinna_openimu::ORIENTATION_AXIS_MINUS_X,
-        imu_aceinna_openimu::ORIENTATION_AXIS_MINUS_Z
-    };
+        imu_aceinna_openimu::ORIENTATION_AXIS_MINUS_Z};
     auto packetEnd = writeConfiguration(&buffer[0], 2, value);
 
-    uint8_t expected[] = {
-        PACKET_START_MARKER, PACKET_START_MARKER, 'u', 'P', 12,
-        2, 0, 0, 0,
-        '+', 'Y', '-', 'X', '-', 'Z', 0, 0,
-        0x79, 0x6f
-    };
+    uint8_t expected[] = {PACKET_START_MARKER,
+        PACKET_START_MARKER,
+        'u',
+        'P',
+        12,
+        2,
+        0,
+        0,
+        0,
+        '+',
+        'Y',
+        '-',
+        'X',
+        '-',
+        'Z',
+        0,
+        0,
+        0x79,
+        0x6f};
 
-    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd),
-        ElementsAreArray(expected));
+    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd), ElementsAreArray(expected));
 }
 
-TEST_F(ProtocolTest, it_queries_a_single_parameter) {
+TEST_F(ProtocolTest, it_queries_a_single_parameter)
+{
     std::vector<uint8_t> buffer(MAX_PACKET_SIZE, 0);
     auto packetEnd = queryConfigurationParameter(&buffer[0], 2);
 
-    uint8_t expected[] = {
-        PACKET_START_MARKER, PACKET_START_MARKER, 'g', 'P', 4,
-        2, 0, 0, 0, 0xA6, 0xD6
-    };
+    uint8_t expected[] =
+        {PACKET_START_MARKER, PACKET_START_MARKER, 'g', 'P', 4, 2, 0, 0, 0, 0xA6, 0xD6};
 
-    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd),
-        ElementsAreArray(expected));
+    ASSERT_THAT(std::vector<uint8_t>(&buffer[0], packetEnd), ElementsAreArray(expected));
 }
 
-TEST_F(ProtocolTest, it_parses_a_single_integer_parameter) {
-    std::vector<uint8_t> buffer = {
-        2, 0, 0, 0,
-        3, 2, 1, 0, 0, 0, 0, 0
-    };
+TEST_F(ProtocolTest, it_parses_a_single_integer_parameter)
+{
+    std::vector<uint8_t> buffer = {2, 0, 0, 0, 3, 2, 1, 0, 0, 0, 0, 0};
     int64_t value = parseConfigurationParameter<int64_t>(&buffer[0], 12, 2);
     ASSERT_EQ(0x010203, value);
 }
 
-TEST_F(ProtocolTest, it_parses_a_single_string_parameter) {
-    std::vector<uint8_t> buffer = {
-        2, 0, 0, 0,
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'
-    };
+TEST_F(ProtocolTest, it_parses_a_single_string_parameter)
+{
+    std::vector<uint8_t> buffer = {2, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
     string value = parseConfigurationParameter<string>(&buffer[0], 12, 2);
     ASSERT_EQ("abcdefgh", value);
 }
 
-TEST_F(ProtocolTest, it_throws_if_the_buffer_is_bigger_than_12_bytes) {
-    ASSERT_THROW({
-        try {
-            parseConfigurationParameter<string>(nullptr, 13, 2);
-        }
-        catch (std::invalid_argument const& e) {
-            ASSERT_EQ("unexpected buffer size for gP response, expected 12 but got 13",
-                      string(e.what()));
-            throw;
-        }
-    }, std::invalid_argument);
+TEST_F(ProtocolTest, it_throws_if_the_buffer_is_bigger_than_12_bytes)
+{
+    ASSERT_THROW(
+        {
+            try {
+                parseConfigurationParameter<string>(nullptr, 13, 2);
+            }
+            catch (std::invalid_argument const& e) {
+                ASSERT_EQ(
+                    "unexpected buffer size for gP response, expected 12 but got 13",
+                    string(e.what()));
+                throw;
+            }
+        },
+        std::invalid_argument);
 }
 
-TEST_F(ProtocolTest, it_throws_if_the_buffer_is_smaller_than_12_bytes) {
-    ASSERT_THROW({
-        try {
-            parseConfigurationParameter<string>(nullptr, 11, 2);
-        }
-        catch (std::invalid_argument const& e) {
-            ASSERT_EQ("unexpected buffer size for gP response, expected 12 but got 11",
-                      string(e.what()));
-            throw;
-        }
-    }, std::invalid_argument);
+TEST_F(ProtocolTest, it_throws_if_the_buffer_is_smaller_than_12_bytes)
+{
+    ASSERT_THROW(
+        {
+            try {
+                parseConfigurationParameter<string>(nullptr, 11, 2);
+            }
+            catch (std::invalid_argument const& e) {
+                ASSERT_EQ(
+                    "unexpected buffer size for gP response, expected 12 but got 11",
+                    string(e.what()));
+                throw;
+            }
+        },
+        std::invalid_argument);
 }
 
-TEST_F(ProtocolTest, it_throws_if_the_parameter_is_not_the_expected_one) {
-    vector<uint8_t> buffer = { 2, 0, 0, 0 };
-    ASSERT_THROW({
-        try {
-            parseConfigurationParameter<string>(&buffer[0], 12, 3);
-        }
-        catch (std::invalid_argument const& e) {
-            ASSERT_EQ("was expecting a read of configuration parameter 3 but got 2",
-                      string(e.what()));
-            throw;
-        }
-    }, std::invalid_argument);
+TEST_F(ProtocolTest, it_throws_if_the_parameter_is_not_the_expected_one)
+{
+    vector<uint8_t> buffer = {2, 0, 0, 0};
+    ASSERT_THROW(
+        {
+            try {
+                parseConfigurationParameter<string>(&buffer[0], 12, 3);
+            }
+            catch (std::invalid_argument const& e) {
+                ASSERT_EQ("was expecting a read of configuration parameter 3 but got 2",
+                    string(e.what()));
+                throw;
+            }
+        },
+        std::invalid_argument);
 }
 
-TEST_F(ProtocolTest, it_formats_a_firmware_block_write_message) {
-    vector<uint8_t> block = { 1, 2, 3, 4 };
+TEST_F(ProtocolTest, it_formats_a_firmware_block_write_message)
+{
+    vector<uint8_t> block = {1, 2, 3, 4};
     vector<uint8_t> packet(MAX_PACKET_SIZE, 0);
 
     auto packetEnd = queryAppBlockWrite(&packet[0], 0x10203040, &block[0], 4);
 
-    uint8_t expected[] = {
-        PACKET_START_MARKER, PACKET_START_MARKER, 'W', 'A', 9,
-        0x10, 0x20, 0x30, 0x40, 4, 1, 2, 3, 4, 0x6d, 0xad
-    };
-    ASSERT_THAT(std::vector<uint8_t>(&packet[0], packetEnd),
-        ElementsAreArray(expected));
+    uint8_t expected[] = {PACKET_START_MARKER,
+        PACKET_START_MARKER,
+        'W',
+        'A',
+        9,
+        0x10,
+        0x20,
+        0x30,
+        0x40,
+        4,
+        1,
+        2,
+        3,
+        4,
+        0x6d,
+        0xad};
+    ASSERT_THAT(std::vector<uint8_t>(&packet[0], packetEnd), ElementsAreArray(expected));
 }
 
-vector<uint8_t> make_byte_sequence(int size) {
+vector<uint8_t> make_byte_sequence(int size)
+{
     vector<uint8_t> bytes;
     bytes.resize(size);
     for (int i = 0; i < size; ++i) {
@@ -309,7 +538,8 @@ vector<uint8_t> make_byte_sequence(int size) {
     return bytes;
 }
 
-TEST_F(ProtocolTest, it_parses_a_status_message) {
+TEST_F(ProtocolTest, it_parses_a_status_message)
+{
     vector<uint8_t> payload(make_byte_sequence(34));
     payload[33] = 0x2c;
     auto status = parseStatus(&payload[0], payload.size());
@@ -328,31 +558,36 @@ TEST_F(ProtocolTest, it_parses_a_status_message) {
     ASSERT_EQ(0x5, status.filter_state.status);
 }
 
-TEST_F(ProtocolTest, it_throws_if_the_payload_buffer_is_smaller_than_the_expected_status_size) {
+TEST_F(ProtocolTest,
+    it_throws_if_the_payload_buffer_is_smaller_than_the_expected_status_size)
+{
     vector<uint8_t> payload;
     payload.resize(33);
     ASSERT_THROW_MESSAGE(parseStatus(&payload[0], payload.size()),
-                         std::invalid_argument, "buffer too small");
+        std::invalid_argument,
+        "buffer too small");
 }
 
-TEST_F(ProtocolTest, it_throws_if_the_payload_buffer_is_bigger_than_the_expected_status_size) {
+TEST_F(ProtocolTest,
+    it_throws_if_the_payload_buffer_is_bigger_than_the_expected_status_size)
+{
     vector<uint8_t> payload;
     payload.resize(35);
     ASSERT_THROW_MESSAGE(parseStatus(&payload[0], payload.size()),
-                         std::invalid_argument, "received status structure bigger than expected");
+        std::invalid_argument,
+        "received status structure bigger than expected");
 }
 
-TEST_F(ProtocolTest, it_converts_ned_to_nwu) {
+TEST_F(ProtocolTest, it_converts_ned_to_nwu)
+{
     base::Orientation orientation;
-    orientation =
-        Eigen::AngleAxisd(M_PI/4, Eigen::Vector3d::UnitZ()) *
-        Eigen::AngleAxisd(M_PI/2, Eigen::Vector3d::UnitY()) *
-        Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
+    orientation = Eigen::AngleAxisd(M_PI / 4, Eigen::Vector3d::UnitZ()) *
+                  Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitY()) *
+                  Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
     orientation = valueNED2NWU(orientation);
     base::Orientation expected;
-    expected =
-        Eigen::AngleAxisd(-M_PI/4, Eigen::Vector3d::UnitZ()) *
-        Eigen::AngleAxisd(-M_PI/2, Eigen::Vector3d::UnitY()) *
-        Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX());
+    expected = Eigen::AngleAxisd(-M_PI / 4, Eigen::Vector3d::UnitZ()) *
+               Eigen::AngleAxisd(-M_PI / 2, Eigen::Vector3d::UnitY()) *
+               Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX());
     ASSERT_EQ(true, expected.isApprox(orientation));
 }


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/drivers-iodrivers_base/pull/50

It acts as a proxy between the IMU and another client (i.e. Syskit),
publishing state as NMEA to a configurable target. This will allow us
to send NMEA state to devices that require it (e.g. the satcoms) without
the involvement from the Syskit system - making sure that that part
works even if the system is down.