### PR TITLE
fix: plotting of the ellipse fit

### DIFF
--- a/scripts/magnetic_calibration.r
+++ b/scripts/magnetic_calibration.r
@@ -94,8 +94,8 @@ get.ellipse <- function( fit, n=360 )
   # n is the number of points to render
 
   tt <- seq(0, 2*pi, length=n)
-  sa <- sin(fit$angle)
-  ca <- cos(fit$angle)
+  sa <- sin(fit$angle + pi/2)
+  ca <- cos(fit$angle + pi/2)
   ct <- cos(tt)
   st <- sin(tt)
 


### PR DESCRIPTION
The generation of the ellipse point was wrong when compared to the raw points. Correct that to allow a visual validation of the result.

This was never seen before because the first motion box does not have any soft iron, and therefore has quasi zero ellipse deformation.
