### PR TITLE
fix: handle zero-terminated strings read from the IMU configuration

### DIFF
--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -267,6 +267,12 @@ string protocol::parseConfigurationParameter<string>(uint8_t* buffer,
     int expectedIndex)
 {
     validateConfigurationParameter(buffer, bufferSize, expectedIndex);
+    for (size_t string_end = 4; string_end < 12; ++string_end) {
+        if (buffer[string_end] == 0) {
+            return string(reinterpret_cast<char const*>(buffer + 4),
+                reinterpret_cast<char const*>(buffer + string_end));
+        }
+    }
     return string(reinterpret_cast<char const*>(buffer + 4),
         reinterpret_cast<char const*>(buffer + 12));
 }

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -451,6 +451,13 @@ TEST_F(ProtocolTest, it_parses_a_single_string_parameter)
     ASSERT_EQ("abcdefgh", value);
 }
 
+TEST_F(ProtocolTest, it_handles_zeroes_in_string_parameter_reads)
+{
+    std::vector<uint8_t> buffer = {2, 0, 0, 0, 'a', 'b', 0, 'd', 'e', 'f', 'g', 'h'};
+    string value = parseConfigurationParameter<string>(&buffer[0], 12, 2);
+    ASSERT_EQ("ab", value);
+}
+
 TEST_F(ProtocolTest, it_throws_if_the_buffer_is_bigger_than_12_bytes)
 {
     ASSERT_THROW(


### PR DESCRIPTION
This was the error that impeded the configuration of motion box v2

I haven't yet had the time to check why it works on v1. It really should not.