### PR TITLE
feat: implement support methods to allow full orogen-side configuration of the IMU

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ rock_library(imu_aceinna_openimu
             PeriodicUpdate.cpp
     HEADERS Protocol.hpp Driver.hpp Configuration.hpp DeviceInfo.hpp
             Endianness.hpp FilterState.hpp Status.hpp MagneticInfo.hpp PeriodicUpdate.hpp
+            MagneticCalibration.hpp
     DEPS_PKGCONFIG base-types iodrivers_base gps_base)
 
 rock_executable(imu_aceinna_openimu_ctl Main.cpp

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -51,6 +51,17 @@ string imu_aceinna_openimu::to_string(Configuration::Orientation const& o)
     return axisToUser(o.forward) + axisToUser(o.right) + axisToUser(o.down);
 }
 
+bool Configuration::operator ==(Configuration const& other) const {
+    return !(*this != other);
+}
+
+bool Configuration::operator !=(Configuration const& other) const {
+    return
+        needsReset(other) ||
+        other.periodic_packet_rate != periodic_packet_rate ||
+        other.periodic_packet_type != periodic_packet_type;
+}
+
 bool Configuration::needsReset(Configuration const& original) const {
     return
         original.acceleration_low_pass_filter != acceleration_low_pass_filter ||
@@ -62,6 +73,6 @@ bool Configuration::needsReset(Configuration const& original) const {
         original.hard_iron[1] != hard_iron[1] ||
         original.soft_iron_ratio != soft_iron_ratio ||
         original.soft_iron_angle != soft_iron_angle ||
-        (original.lever_arm - lever_arm).norm() < 1e-3 ||
-        (original.point_of_interest - point_of_interest).norm() < 1e-3;
+        (original.lever_arm - lever_arm).norm() > 1e-3 ||
+        (original.point_of_interest - point_of_interest).norm() > 1e-3;
 }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -50,3 +50,18 @@ string imu_aceinna_openimu::to_string(Configuration::Orientation const& o)
 {
     return axisToUser(o.forward) + axisToUser(o.right) + axisToUser(o.down);
 }
+
+bool Configuration::needsReset(Configuration const& original) const {
+    return
+        original.acceleration_low_pass_filter != acceleration_low_pass_filter ||
+        original.angular_velocity_low_pass_filter != angular_velocity_low_pass_filter ||
+        original.orientation != orientation ||
+        original.gps_protocol != gps_protocol ||
+        original.gps_baud_rate != gps_baud_rate ||
+        original.hard_iron[0] != hard_iron[0] ||
+        original.hard_iron[1] != hard_iron[1] ||
+        original.soft_iron_ratio != soft_iron_ratio ||
+        original.soft_iron_angle != soft_iron_angle ||
+        (original.lever_arm - lever_arm).norm() < 1e-3 ||
+        (original.point_of_interest - point_of_interest).norm() < 1e-3;
+}

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -55,6 +55,9 @@ namespace imu_aceinna_openimu {
 
         base::Vector3d lever_arm;
         base::Vector3d point_of_interest;
+
+        /** Whether the IMU needs to be reset because of changes from original to self */
+        bool needsReset(Configuration const& original) const;
     };
 
     inline std::string to_string(std::string const& value)

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -56,6 +56,9 @@ namespace imu_aceinna_openimu {
         base::Vector3d lever_arm;
         base::Vector3d point_of_interest;
 
+        bool operator ==(Configuration const& other) const;
+        bool operator !=(Configuration const& other) const;
+
         /** Whether the IMU needs to be reset because of changes from original to self */
         bool needsReset(Configuration const& original) const;
     };

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -234,6 +234,14 @@ void Driver::writePointOfInterest(base::Vector3d const& point)
     writeConfiguration<double>(19, point.z());
 }
 
+void Driver::writeMagneticCalibration(MagneticCalibration const& calibration)
+{
+    writeConfiguration<double>(10, calibration.hard_iron.x());
+    writeConfiguration<double>(11, calibration.hard_iron.y());
+    writeConfiguration<double>(12, calibration.soft_iron_ratio);
+    writeConfiguration<double>(13, calibration.soft_iron_angle.getRad());
+}
+
 int Driver::extractPacket(uint8_t const* buffer, size_t bufferSize) const
 {
     return protocol::extractPacket(buffer, bufferSize);

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -112,6 +112,24 @@ void Driver::queryReset()
     writePacket(mWriteBuffer, packetEnd - mWriteBuffer);
 }
 
+Configuration Driver::reset(int tries)
+{
+    queryReset();
+
+    for (int i = 0; i < tries; ++i) {
+        try {
+            return readConfiguration();
+        }
+        catch(iodrivers_base::TimeoutError&) {
+        }
+    }
+
+    throw ResetFailedError(
+        "failed to communicate with the IMU after reset, tried " +
+        std::to_string(tries) + " times"
+    );
+}
+
 void Driver::queryRestoreDefaultConfiguration()
 {
     auto packetEnd = protocol::queryRestoreDefaultConfiguration(mWriteBuffer);

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -3,6 +3,7 @@
 
 #include <imu_aceinna_openimu/Configuration.hpp>
 #include <imu_aceinna_openimu/DeviceInfo.hpp>
+#include <imu_aceinna_openimu/MagneticCalibration.hpp>
 #include <imu_aceinna_openimu/PeriodicUpdate.hpp>
 #include <imu_aceinna_openimu/Status.hpp>
 #include <iodrivers_base/Driver.hpp>
@@ -119,6 +120,9 @@ namespace imu_aceinna_openimu {
 
         /** Configure the point of interest */
         void writePointOfInterest(base::Vector3d const& point);
+
+        /** Configure the magnetic distortion compensation */
+        void writeMagneticCalibration(MagneticCalibration const& calibration);
 
         /** Save the configuration to flash */
         void saveConfiguration();

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -46,6 +46,10 @@ namespace imu_aceinna_openimu {
     public:
         Driver();
 
+        struct ResetFailedError : public std::runtime_error {
+            using std::runtime_error::runtime_error;
+        };
+
         struct UnsupportedDevice : public std::runtime_error {
             using std::runtime_error::runtime_error;
         };
@@ -70,6 +74,16 @@ namespace imu_aceinna_openimu {
 
         /** Reset the unit */
         void queryReset();
+
+        /** Reset the unit and wait for it to be alive again
+         *
+         * The method tries to read the configuration to check whether the IMU
+         * is alive.
+         *
+         * @param tries how many times the method tries to read configuration before
+         *    bailing out.
+        */
+        Configuration reset(int tries = 10);
 
         /** Restore the default configuration and save it to flash */
         void queryRestoreDefaultConfiguration();

--- a/src/MagneticCalibration.hpp
+++ b/src/MagneticCalibration.hpp
@@ -1,0 +1,19 @@
+#ifndef IMU_ACEINNA_OPENIMU_MAGNETICCALIBRATION_HPP
+#define IMU_ACEINNA_OPENIMU_MAGNETICCALIBRATION_HPP
+
+#include <base/Eigen.hpp>
+#include <base/Angle.hpp>
+
+namespace imu_aceinna_openimu {
+    /** Configuration of magnetic distortion compensation
+     *
+     * See README for the general procedure
+     */
+    struct MagneticCalibration {
+        base::Vector2d hard_iron = base::Vector2d::Zero();
+        base::Angle soft_iron_angle = base::Angle::fromRad(0);
+        float soft_iron_ratio = 1;
+    };
+}
+
+#endif

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -303,6 +303,8 @@ int main(int argc, char** argv)
         driver.openURI(uri);
         driver.validateDevice();
         driver.saveConfiguration();
+        std::cout << "Confguration written on permanent storage\n"
+                     "Some parameter changes might need a reset to be effective\n";
     }
     else if (cmd == "set-rate") {
         if (argc != 4) {
@@ -404,7 +406,8 @@ int main(int argc, char** argv)
     }
     else if (cmd == "reset") {
         driver.openURI(uri);
-        driver.queryReset();
+        driver.reset();
+        std::cout << "IMU successfully reset" << std::endl;
     }
     else {
         cerr << "unexpected command " << cmd << endl;

--- a/test/test_Configuration.cpp
+++ b/test/test_Configuration.cpp
@@ -4,6 +4,7 @@
 using namespace imu_aceinna_openimu;
 
 struct ConfigurationOrientationTest : public ::testing::Test {};
+struct ConfigurationTest : public ::testing::Test {};
 
 TEST_F(ConfigurationOrientationTest, it_is_equal_if_all_three_fields_are)
 {
@@ -63,4 +64,19 @@ TEST_F(ConfigurationOrientationTest, it_formats_itself_to_string)
         ORIENTATION_AXIS_MINUS_Y,
         ORIENTATION_AXIS_MINUS_Z);
     ASSERT_EQ("-X-Y-Z", to_string(confminus));
+}
+
+TEST_F(ConfigurationTest, it_equals_its_copy)
+{
+    Configuration config;
+    Configuration other = config;
+    ASSERT_EQ(config, other);
+}
+
+TEST_F(ConfigurationTest, it_differs_if_the_periodic_packet_type_is_different)
+{
+    Configuration config;
+    Configuration other = config;
+    other.periodic_packet_type = "some";
+    ASSERT_NE(config, other);
 }


### PR DESCRIPTION
Currently, we configure the IMU once and for all "on the side" and save the config. Two reasons for this: one is
that it makes the IMU active "at boot", leaving it converging while Syskit and the other software are starting,
the other is that we need to reset the IMU for some (but not all) configuration changes.

This makes magnetic calibration extremely painful, even more so now that we want to run the IMU-related
components on their respective beaglebone to avoid the UDP-basedc forwarding.

This implements the necessary support methods for the orogen component to configure everything. It has been
tested on the motion box v2.