### PR TITLE
fix: maintain NaN values when not in INS mode

### DIFF
--- a/src/PeriodicUpdate.cpp
+++ b/src/PeriodicUpdate.cpp
@@ -5,6 +5,10 @@ using namespace imu_aceinna_openimu;
 
 void PeriodicUpdate::computeNWUPosition(gps_base::UTMConverter const& converter)
 {
+    if (filter_state.mode != FilterMode::OPMODE_INS) {
+        return;
+    }
+
     gps_base::Solution latlonalt;
     latlonalt.latitude = latitude.getDeg();
     latlonalt.longitude = longitude.getDeg();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 rock_gtest(test_suite suite.cpp
-   test_Protocol.cpp test_Driver.cpp test_Configuration.cpp
+   test_Protocol.cpp test_Driver.cpp test_Configuration.cpp test_PeriodicUpdate.cpp
    DEPS imu_aceinna_openimu)
 
 rock_gtest(test_NMEAPublisher suite.cpp

--- a/test/test_PeriodicUpdate.cpp
+++ b/test/test_PeriodicUpdate.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h>
+#include <imu_aceinna_openimu/PeriodicUpdate.hpp>
+
+struct PeriodicUpdateTest : public ::testing::Test {
+    PeriodicUpdateTest()
+    {
+    }
+};
+
+TEST_F(PeriodicUpdateTest, it_computes_nan_nwu_position_if_input_is_nan)
+{
+    imu_aceinna_openimu::PeriodicUpdate update;
+    update.filter_state.mode = imu_aceinna_openimu::FilterMode::OPMODE_AHRS_LOW_GAIN;
+
+    update.computeNWUPosition(
+        gps_base::UTMConverter(gps_base::UTMConversionParameters()));
+
+    EXPECT_TRUE(std::isnan(update.rbs.position[0]));
+    EXPECT_TRUE(std::isnan(update.rbs.position[1]));
+    EXPECT_TRUE(std::isnan(update.rbs.position[2]));
+}


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/bundles-wetpaint/pull/606

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
[sc-40025]
- [ ] [Shortcut](http://) -->
When converting an invalid RBS to UTM the returning position became Infinity, which could poison another components (wave filter task, in this case) that expect invalid values to be unknown (NaN).
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
Unit test
# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
