### PR TITLE
chore: do quaternion rotation from quaternion without passing by a 3x3 matrix

### DIFF
--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -396,10 +396,22 @@ Status protocol::parseStatus(uint8_t const* buffer, int size)
     return ret;
 }
 
-template <typename H> H protocol::covarianceNED2NWU(H neu)
+// Transformation that rotates by PI the X axis. Usefull for NED/NWU convertions
+static const Eigen::Matrix3d RotNED2NWU_mat(
+    base::AngleAxisd(M_PI, base::Vector3d::UnitX()));
+static const Eigen::Quaterniond RotNED2NWU_q(
+    base::AngleAxisd(M_PI, base::Vector3d::UnitX()));
+static const Eigen::Matrix3d RotNWU2NED_mat(
+    base::AngleAxisd(-M_PI, base::Vector3d::UnitX()));
+
+Eigen::Quaterniond protocol::valueNED2NWU(Eigen::Quaterniond const& ned)
 {
-    neu = RotNED2NWU * neu * RotNWU2NED;
-    return neu;
+    return RotNED2NWU_q * ned;
+}
+
+Eigen::Matrix3d protocol::covarianceNED2NWU(Eigen::Matrix3d const& ned)
+{
+    return RotNED2NWU_mat * ned * RotNWU2NED_mat;
 }
 
 PeriodicUpdate protocol::parseE2Output(uint8_t const* buffer, int bufferSize)

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -21,11 +21,9 @@ namespace imu_aceinna_openimu {
         static const int MAX_PACKET_SIZE = MIN_PACKET_SIZE + 256;
         // Biggest block that can be written when flashing the firmware
         static const int MAX_APP_BLOCK_SIZE = 240;
-        // Transformation that rotates by PI the X axis. Usefull for NED/NWU convertions
-        static const base::Matrix3d RotNED2NWU(
-            base::AngleAxisd(M_PI, base::Vector3d::UnitX()));
-        static const base::Matrix3d RotNWU2NED(
-            base::AngleAxisd(-M_PI, base::Vector3d::UnitX()));
+
+        Eigen::Quaterniond valueNED2NWU(Eigen::Quaterniond const& ned);
+        Eigen::Matrix3d covarianceNED2NWU(Eigen::Matrix3d const& ned);
 
         enum WriteStatus {
             WRITE_STATUS_OK = 0,
@@ -132,13 +130,6 @@ namespace imu_aceinna_openimu {
         /** Parse the unit status response (gS)
          */
         Status parseStatus(uint8_t const* buffer, int size);
-
-        template <typename T> T valueNED2NWU(T neu)
-        {
-            return static_cast<T>(RotNED2NWU * neu);
-        }
-
-        template <typename H> H covarianceNED2NWU(H neu);
 
         /** Parse the stock INS output message (e2) */
         PeriodicUpdate parseE2Output(uint8_t const* buffer, int bufferSize);

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -572,7 +572,7 @@ TEST_F(ProtocolTest, it_converts_ned_to_nwu)
     expected = Eigen::AngleAxisd(-M_PI / 4, Eigen::Vector3d::UnitZ()) *
                Eigen::AngleAxisd(-M_PI / 2, Eigen::Vector3d::UnitY()) *
                Eigen::AngleAxisd(0, Eigen::Vector3d::UnitX());
-    ASSERT_EQ(true, expected.isApprox(orientation));
+    ASSERT_NEAR(expected.angularDistance(orientation), 0, 1e-3);
 }
 
 TEST_F(ProtocolTest, it_parses_a_e4_INS_message)


### PR DESCRIPTION
Note: when we come to use the covariance transform, should do the NED2NWU by hand (since it's essentially swapping some values) instead of using rotation matrices.